### PR TITLE
Super simple demo script to make things easy

### DIFF
--- a/demo_emr.sh
+++ b/demo_emr.sh
@@ -1,0 +1,18 @@
+# Run the prediction passing in the Spark event log and cluster config.
+# Save the prediction Id.
+prediction_id=`sync-cli predictions create aws-emr -e demo/emr/application_1678162862227_0001 -c demo/emr/emr-config.json | sed 's/Prediction ID: //'`
+echo "Prediction Id: $prediction_id"
+
+# Wait 10 seconds for the prediction run to complete.
+sleep 10
+
+# Get the status for the predition run.
+status=`sync-cli predictions status $prediction_id`
+echo "Prediction completed with status: $status"
+
+# If success, save results to a file.
+if [ "$status" = "SUCCESS" ]
+then
+    sync-cli predictions get $prediction_id > demo/emr/result.json
+    echo "Result written to demo/emr/result.json"
+fi


### PR DESCRIPTION
Adding a super-simple-low-tech demo script which makes it easy for users to run a prediction using the Sync CLI. The low-tech aspect makes it easy to see the Sync CLI commands used to run a prediction, query status, and get results.

Adding logic to loop on status etc added unnecessary complexity and diminished the Sync CLI.
Keeping it super simple made the most sense.