### PR TITLE
Bypass Python 3.10 check

### DIFF
--- a/demo/install_cli.sh
+++ b/demo/install_cli.sh
@@ -6,10 +6,10 @@ SYNC_HOME="$(dirname "$(dirname "$(readlink -f $0)")")"
 function install_sync() {
   local SYNC_PYTHON="$(command -v python3 python | sed q)"
 
-  if ! [[ $("$SYNC_PYTHON" --version 2>/dev/null) =~ (^|[^[:digit:].])3.10(\.|$) ]]; then
-    >&2 echo "Python 3.10 is required"
-    return 1
-  fi
+  # if ! [[ $("$SYNC_PYTHON" --version 2>/dev/null) =~ (^|[^[:digit:].])3.10(\.|$) ]]; then
+  #  >&2 echo "Python 3.10 is required"
+  #  return 1
+  # fi
 
   if [[ -z $VIRTUAL_ENV ]]; then
     if ! { "$SYNC_PYTHON" -m venv "$SYNC_HOME/venv" && source "$SYNC_HOME/venv/bin/activate"; }; then


### PR DESCRIPTION
Appears to be some issues with the Python 3.10 check. Disabling this for now.