### PR TITLE
Revert product list API change

### DIFF
--- a/sync/cli/__init__.py
+++ b/sync/cli/__init__.py
@@ -76,11 +76,11 @@ def configure():
 
 
 @main.command
-def platforms():
-    """List supported platforms"""
+def products():
+    """List supported products"""
     products_response = get_products()
     if products := products_response.result:
-        click.echo(", ".join(product for product in products if product != "aws-databricks"))
+        click.echo(", ".join(products))
     else:
         click.echo(str(products_response.error), err=True)
 

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -58,7 +58,7 @@ class SyncClient:
         )
 
     def get_products(self) -> dict:
-        return self._send(self._client.build_request("GET", "/v1/autotuner/platforms"))
+        return self._send(self._client.build_request("GET", "/v1/autotuner/products"))
 
     def create_prediction(self, prediction: dict) -> dict:
         headers, content = encode_json(prediction)


### PR DESCRIPTION
Reverts a change to the CLI that incorrectly anticipated a web API change. Instead of,
```
% sync-cli platforms
aws-emr, aws-databricks
```
it's
```
% sync-cli products
aws-emr, aws-databricks
```

This also stops hiding "aws-databricks" which was missed in a prior PR.