### PR TITLE
Pin hatchling to version 1.8.0 to fix Databricks Runtime pathspec compatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.8.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,11 @@
 [build-system]
+# NOTE - versions of Hatchling more recent than 1.8.0 have a dependency on pathspec >= 0.10.1. However,
+#  Databricks Runtime versions only have pathspec==0.9.0 installed, and so attempting to `pip install ...`
+#  syncsparkpy will fail with an `AttributeError`. Pinning Hatching to this version, which is the most
+#  recent version to only require pathspec >= 0.9.0, resolves that issue without asking the user to
+#  install pathspec >= 0.10.1 on their Databricks clusters. We should only ever upgrade this version once
+#  most/all Databricks Runtime LTS releases support pathspec >= 0.10.1, which may be a while...
+# See here for DBR release notes - https://docs.databricks.com/release-notes/runtime/releases.html
 requires = ["hatchling==1.8.0"]
 build-backend = "hatchling.build"
 

--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
Hatching 1.9.0+ requires `pathspec >= 0.10.1`, but even the most recent Databricks Runtime release (DBR 13) only has `pathspec==0.9.0` installed - https://docs.databricks.com/release-notes/runtime/13.0.html#system-environment. This causes build failures when trying to `%pip install syncsparkpy` in Databricks notebooks using the most recent version of `hatchling` - 

```python
Note: you may need to restart the kernel using dbutils.library.restartPython() to use updated packages.
Collecting https://github.com/synccomputingcode/syncsparkpy/archive/main.tar.gz
  Using cached https://github.com/synccomputingcode/syncsparkpy/archive/main.tar.gz
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [31 lines of output]
      Traceback (most recent call last):
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-dbde249e-c02c-4ff4-a6ba-19f42b016fe2/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 156, in prepare_metadata_for_build_wheel
          hook = backend.prepare_metadata_for_build_wheel
      AttributeError: module 'hatchling.build' has no attribute 'prepare_metadata_for_build_wheel'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-dbde249e-c02c-4ff4-a6ba-19f42b016fe2/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-dbde249e-c02c-4ff4-a6ba-19f42b016fe2/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-dbde249e-c02c-4ff4-a6ba-19f42b016fe2/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 160, in prepare_metadata_for_build_wheel
          whl_basename = backend.build_wheel(metadata_directory, config_settings)
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/build.py", line 56, in build_wheel
          return os.path.basename(next(builder.build(wheel_directory, ['standard'])))
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/plugin/interface.py", line 158, in build
          artifact = version_api[version](directory, **build_data)
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/wheel.py", line 370, in build_standard
          for included_file in self.recurse_included_files():
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/plugin/interface.py", line 182, in recurse_included_files
          yield from self.recurse_project_files()
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/plugin/interface.py", line 196, in recurse_project_files
          if self.config.include_path(relative_file_path, is_package=is_package):
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 94, in include_path
          and not self.path_is_excluded(relative_path)
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 106, in path_is_excluded
          if self.exclude_spec is None:
        File "/tmp/pip-build-env-23rqoml2/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 207, in exclude_spec
          self.__exclude_spec = pathspec.GitIgnoreSpec.from_lines(all_exclude_patterns)
      AttributeError: module 'pathspec' has no attribute 'GitIgnoreSpec'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

Pinning `hatchling` to a version compatible with `pathspec 0.9.0` fixes the issue and the library installs successfully