### PR TITLE
PROD-820 Expand supported the library's Python versions to [3.7,3.11]

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.10.x
+      - name: Set up Python 3.7.x
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10.9"
+          python-version: "3.7.5"
 
       - name: Install dependencies
         run: pip install .[dev]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.7.5"
       - name: Install dependencies
         run: pip install .[dev]
       - name: Build docs

--- a/demo/install_cli.sh
+++ b/demo/install_cli.sh
@@ -7,7 +7,7 @@ function find_python() {
   local python_candidate
 
   while read python_candidate; do
-    if [[ $("$python_candidate" --version 2>/dev/null) =~ (^|[^[:digit:].])3.10(\.|$) ]]; then
+    if [[ $("$python_candidate" --version 2>/dev/null) =~ (^|[^[:digit:].])3.[7,8,9,10,11](\.|$) ]]; then
       echo $python_candidate
       return
     fi

--- a/demo/install_cli.sh
+++ b/demo/install_cli.sh
@@ -7,7 +7,7 @@ function find_python() {
   local python_candidate
 
   while read python_candidate; do
-    if [[ $("$python_candidate" --version 2>/dev/null) =~ (^|[^[:digit:].])3.[7,8,9,10,11](\.|$) ]]; then
+    if [[ $("$python_candidate" --version 2>/dev/null) =~ (^|[^[:digit:].])3\.(7|8|9|10|11)(\.|$) ]]; then
       echo $python_candidate
       return
     fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = [
   "pytest==7.2.0",
   "pytest-env==0.8.1",
   "pytest-asyncio==0.21.0",
-  "Sphinx==5.3.0",
+  "Sphinx==4.3.0",
   "respx==0.20.1",
   "deepdiff==6.3.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "hatchling.build"
 name = "syncsparkpy"
 authors = [{"name" = "Sync Computing"}]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 classifiers = [
   "Intended Audience :: Information Technology",
   "Intended Audience :: System Administrators",
@@ -59,7 +59,7 @@ Home = "https://github.com/synccomputingcode/syncsparkpy"
 
 [tool.black]
 line-length = 100
-target-version = ['py310']
+target-version = ['py37']
 
 [tool.isort]
 profile = "black"

--- a/sync/api/predictions.py
+++ b/sync/api/predictions.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import boto3 as boto
 import httpx
+from typing import List
 
 from sync.clients.sync import get_default_client
 from sync.models import Platform, PredictionError, Response
@@ -15,7 +16,7 @@ from sync.models import Platform, PredictionError, Response
 logger = logging.getLogger(__name__)
 
 
-def get_products() -> Response[list[str]]:
+def get_products() -> Response[List[str]]:
     """Get supported platforms
 
     :return: list of platform names
@@ -111,7 +112,7 @@ def get_status(prediction_id: str) -> Response[str]:
 
 def get_predictions(
     product: str = None, project_id: str = None, preference: str = None
-) -> Response[list[dict]]:
+) -> Response[List[dict]]:
     """Get predictions
 
     :param product: platform to filter by, e.g. "aws-emr", defaults to None

--- a/sync/api/predictions.py
+++ b/sync/api/predictions.py
@@ -221,16 +221,16 @@ def create_prediction(
     :return: prediction ID
     :rtype: Response[str]
     """
-    match urlparse(eventlog_url).scheme:
-        case "s3":
-            response = generate_presigned_url(eventlog_url)
-            if response.error:
-                return response
-            eventlog_http_url = response.result
-        case "http" | "https":
-            eventlog_http_url = eventlog_url
-        case _:
-            return Response(error=PredictionError(message="Unsupported event log URL scheme"))
+    scheme = urlparse(eventlog_url).scheme
+    if scheme == "s3":
+        response = generate_presigned_url(eventlog_url)
+        if response.error:
+            return response
+        eventlog_http_url = response.result
+    elif scheme in {"http", "https"}:
+        eventlog_http_url = eventlog_url
+    else:
+        return Response(error=PredictionError(message="Unsupported event log URL scheme"))
 
     response = get_default_client().create_prediction(
         {

--- a/sync/api/predictions.py
+++ b/sync/api/predictions.py
@@ -43,7 +43,8 @@ def generate_prediction(
     """
     response = create_prediction(platform, cluster_report, eventlog_url)
 
-    if prediction_id := response.result:
+    prediction_id = response.result
+    if prediction_id:
         return wait_for_prediction(prediction_id, preference)
 
     return response
@@ -60,8 +61,8 @@ def wait_for_prediction(prediction_id: str, preference: str = None) -> Response[
     :rtype: Response[dict]
     """
     response = wait_for_final_prediction_status(prediction_id)
-
-    if result := response.result:
+    result = response.result
+    if result:
         if result == "SUCCESS":
             return get_prediction(prediction_id, preference)
 
@@ -84,7 +85,8 @@ def get_prediction(prediction_id: str, preference: str = None) -> Response[dict]
         prediction_id, {"preference": preference} if preference else None
     )
 
-    if result := response.get("result"):
+    result = response.get("result")
+    if result:
         return Response(result=result)
 
     return Response(**response)
@@ -100,7 +102,8 @@ def get_status(prediction_id: str) -> Response[str]:
     """
     response = get_default_client().get_prediction_status(prediction_id)
 
-    if result := response.get("result"):
+    result = response.get("result")
+    if result:
         return Response(result=result["status"])
 
     return Response(**response)
@@ -144,8 +147,10 @@ def wait_for_final_prediction_status(prediction_id: str) -> Response[str]:
     :return: prediction status, e.g. "SUCCESS"
     :rtype: Response[str]
     """
-    while response := get_default_client().get_prediction_status(prediction_id):
-        if result := response.get("result"):
+    response = get_default_client().get_prediction_status(prediction_id)
+    while response:
+        result = response.get("result")
+        if result:
             if result["status"] in ("SUCCESS", "FAILURE"):
                 return Response(result=result["status"])
         else:
@@ -153,6 +158,8 @@ def wait_for_final_prediction_status(prediction_id: str) -> Response[str]:
 
         logger.info("Waiting for prediction")
         sleep(10)
+
+        response = get_default_client().get_prediction_status(prediction_id)
 
     return Response(error=PredictionError(message="Failed to get prediction status"))
 

--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from typing import List
+
 from sync.api.predictions import get_predictions
 from sync.clients.sync import get_default_client
 from sync.models import Preference, ProjectError, Response
@@ -21,14 +23,16 @@ def get_prediction(project_id: str, preference: Preference = None) -> Response[d
     :rtype: Response[dict]
     """
     project_response = get_project(project_id)
-    if project := project_response.result:
+    project = project_response.result
+    if project:
         predictions_response = get_predictions(
             project_id=project_id, preference=preference or project.get("preference")
         )
         if predictions_response.error:
             return predictions_response
 
-        if predictions := predictions_response.result:
+        predictions = predictions_response.result
+        if predictions:
             return Response(result=predictions[0])
         return Response(error=ProjectError(message="No predictions in the project"))
     return project_response
@@ -123,13 +127,14 @@ def get_project_by_app_id(app_id: str) -> Response[dict]:
     if response.get("error"):
         return Response(**response)
 
-    if projects := response.get("result"):
+    projects = response.get("result")
+    if projects:
         return Response(result=projects[0])
 
     return Response(error=ProjectError(message=f"No project found for '{app_id}'"))
 
 
-def get_projects(app_id: str = None) -> Response[list[dict]]:
+def get_projects(app_id: str = None) -> Response[List[dict]]:
     """Returns all projects authorized by the API key
 
     :param app_id: app ID to filter by, defaults to None

--- a/sync/asyncapi/predictions.py
+++ b/sync/asyncapi/predictions.py
@@ -2,6 +2,8 @@ import logging
 from asyncio import sleep
 from urllib.parse import urlparse
 
+from typing import List
+
 from sync.api.predictions import generate_presigned_url
 from sync.clients.sync import get_default_async_client
 from sync.models import Platform, PredictionError, Response
@@ -27,7 +29,8 @@ async def generate_prediction(
     """
     response = await create_prediction(platform, cluster_report, eventlog_url)
 
-    if prediction_id := response.result:
+    prediction_id = response.result
+    if prediction_id:
         return await wait_for_prediction(prediction_id, preference)
 
     return response
@@ -45,7 +48,8 @@ async def wait_for_prediction(prediction_id: str, preference: str) -> Response[d
     """
     response = await wait_for_final_prediction_status(prediction_id)
 
-    if result := response.result:
+    result = response.result
+    if result:
         if result == "SUCCESS":
             return await get_prediction(prediction_id, preference)
 
@@ -68,7 +72,8 @@ async def get_prediction(prediction_id: str, preference: str = None) -> Response
         prediction_id, {"preference": preference} if preference else None
     )
 
-    if result := response.get("result"):
+    result = response.get("result")
+    if result:
         return Response(result=result)
 
     return Response(**response)
@@ -76,7 +81,7 @@ async def get_prediction(prediction_id: str, preference: str = None) -> Response
 
 async def get_predictions(
     product: str = None, project_id: str = None, preference: str = None
-) -> Response[list[dict]]:
+) -> Response[List[dict]]:
     """Get predictions
 
     :param product: platform to filter by, e.g. "aws-emr", defaults to None
@@ -112,8 +117,10 @@ async def wait_for_final_prediction_status(prediction_id: str) -> Response[str]:
     :return: prediction status, e.g. "SUCCESS"
     :rtype: Response[str]
     """
-    while response := await get_default_async_client().get_prediction_status(prediction_id):
-        if result := response.get("result"):
+    response = await get_default_async_client().get_prediction_status(prediction_id)
+    while response:
+        result = response.get("result")
+        if result:
             if result["status"] in ("SUCCESS", "FAILURE"):
                 return Response(result=result["status"])
         else:
@@ -121,6 +128,8 @@ async def wait_for_final_prediction_status(prediction_id: str) -> Response[str]:
 
         logger.info("Waiting for prediction")
         await sleep(10)
+
+        response = await get_default_async_client().get_prediction_status(prediction_id)
 
     return Response(error=PredictionError(message="Failed to get prediction status"))
 

--- a/sync/asyncawsemr.py
+++ b/sync/asyncawsemr.py
@@ -36,12 +36,14 @@ async def create_prediction_for_cluster(cluster_id: str, region_name: str = None
     :rtype: Response[str]
     """
     report_response = get_cluster_report(cluster_id, region_name)
-    if cluster_report := report_response.result:
+    cluster_report = report_response.result
+    if cluster_report:
         eventlog_response = _get_eventlog_url_from_cluster_report(cluster_report)
         if eventlog_response.error:
             return eventlog_response
 
-        if eventlog_http_url := eventlog_response.result:
+        eventlog_http_url = eventlog_response.result
+        if eventlog_http_url:
             return await create_prediction(Platform.AWS_EMR, cluster_report, eventlog_http_url)
 
         return eventlog_response

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -8,7 +8,7 @@ import zipfile
 from collections.abc import Collection
 from pathlib import Path
 from time import sleep
-from typing import Any, TypeVar, Union, Tuple
+from typing import Any, TypeVar, Union, Tuple, Dict, List
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -933,7 +933,7 @@ def monitor_cluster(cluster_id: str, polling_period: int = 30) -> None:
         logger.warning("Unable to monitor cluster due to missing cluster log destination - exiting")
 
 
-def _get_job_cluster(tasks: list[dict], job_clusters: list) -> Response[dict]:
+def _get_job_cluster(tasks: List[dict], job_clusters: list) -> Response[dict]:
     if len(tasks) == 1:
         return _get_task_cluster(tasks[0], job_clusters)
 
@@ -947,7 +947,7 @@ def _get_job_cluster(tasks: list[dict], job_clusters: list) -> Response[dict]:
     return Response(error=DatabricksError(message="Not all tasks use the same cluster"))
 
 
-def _get_run_cluster_id(tasks: list[dict]) -> Response[str]:
+def _get_run_cluster_id(tasks: List[dict]) -> Response[str]:
     cluster_ids = {task["cluster_instance"]["cluster_id"] for task in tasks}
     num_ids = len(cluster_ids)
 
@@ -974,7 +974,7 @@ def _get_task_cluster(task: dict, clusters: list) -> Response[dict]:
     return Response(result=cluster)
 
 
-def _s3_contents_have_all_rollover_logs(contents: list[dict], run_end_time_seconds: float):
+def _s3_contents_have_all_rollover_logs(contents: List[dict], run_end_time_seconds: float):
     final_rollover_log = contents and next(
         (
             content
@@ -1090,8 +1090,8 @@ KeyType = TypeVar("KeyType")
 
 
 def _deep_update(
-    mapping: dict[KeyType, Any], *updating_mappings: dict[KeyType, Any]
-) -> dict[KeyType, Any]:
+    mapping: Dict[KeyType, Any], *updating_mappings: Dict[KeyType, Any]
+) -> Dict[KeyType, Any]:
     updated_mapping = mapping.copy()
     for updating_mapping in updating_mappings:
         for k, v in updating_mapping.items():

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -8,7 +8,7 @@ import zipfile
 from collections.abc import Collection
 from pathlib import Path
 from time import sleep
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union, Tuple
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -120,7 +120,7 @@ def create_prediction_for_run(
     compute_type: str,
     project_id: str = None,
     allow_incomplete_cluster_report: bool = False,
-    exclude_tasks: Collection[str] | None = None,
+    exclude_tasks: Union[Collection[str], None] = None,
 ) -> Response[str]:
     """Create a prediction for the specified Databricks run.
 
@@ -183,7 +183,7 @@ def get_cluster_report(
     plan_type: str,
     compute_type: str,
     allow_incomplete: bool = False,
-    exclude_tasks: Collection[str] | None = None,
+    exclude_tasks: Union[Collection[str], None] = None,
 ) -> Response[DatabricksClusterReport]:
     """Fetches the cluster information required to create a Sync prediction
 
@@ -220,7 +220,7 @@ def get_cluster_report(
 
 def _get_cluster_report(
     cluster_id: str, plan_type: str, compute_type: str, allow_incomplete: bool
-) -> Response[DatabricksClusterReport | dict]:
+) -> Response[Union[DatabricksClusterReport, dict]]:
     # Cluster `terminated_time` can be a few seconds after the start of the next task in which
     # this may be executing.
     cluster_response = _wait_for_cluster_termination(cluster_id, timeout_seconds=60, poll_seconds=5)
@@ -248,7 +248,7 @@ def _get_cluster_report(
     )
 
 
-def _get_cluster_instances(cluster: dict) -> dict | DatabricksError:
+def _get_cluster_instances(cluster: dict) -> Union[dict, DatabricksError]:
     cluster_instances = None
     aws_region_name = DB_CONFIG.aws_region_name
 
@@ -298,7 +298,7 @@ def _get_cluster_instances(cluster: dict) -> dict | DatabricksError:
     return cluster_instances
 
 
-def _cluster_log_destination(cluster: dict) -> tuple[str, str, str] | None:
+def _cluster_log_destination(cluster: dict) -> Union[Tuple[str, str, str], None]:
     log_url = cluster.get("cluster_log_conf", {}).get("s3", {}).get("destination")
     if log_url:
         parsed_log_url = urlparse(log_url)
@@ -321,7 +321,7 @@ def record_run(
     compute_type: str,
     project_id: str,
     allow_incomplete_cluster_report: bool = False,
-    exclude_tasks: Collection[str] | None = None,
+    exclude_tasks: Union[Collection[str], None] = None,
 ) -> Response[str]:
     """See :py:func:`~create_prediction_for_run`
 

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -5,10 +5,9 @@ import io
 import logging
 import time
 import zipfile
-from collections.abc import Collection
 from pathlib import Path
 from time import sleep
-from typing import Any, TypeVar, Union, Tuple, Dict, List
+from typing import Any, Dict, List, Tuple, TypeVar, Union, Collection
 from urllib.parse import urlparse
 
 import boto3 as boto

--- a/sync/cli/__init__.py
+++ b/sync/cli/__init__.py
@@ -89,7 +89,8 @@ def configure():
 def products():
     """List supported products"""
     products_response = get_products()
-    if products := products_response.result:
+    products = products_response.result
+    if products:
         click.echo(", ".join(products))
     else:
         click.echo(str(products_response.error), err=True)

--- a/sync/cli/awsdatabricks.py
+++ b/sync/cli/awsdatabricks.py
@@ -25,7 +25,8 @@ def aws_databricks():
 def run_prediction(job_id: str, prediction_id: str, preference: str = None):
     """Apply a prediction to a job and run it"""
     run = awsdatabricks.run_prediction(job_id, prediction_id, preference)
-    if run_id := run.result:
+    run_id = run.result
+    if run_id:
         click.echo(f"Run ID: {run_id}")
     else:
         click.echo(str(run.error), err=True)
@@ -45,7 +46,8 @@ def run_job(
 ):
     """Run a job, wait for it to complete then create a prediction"""
     run_response = awsdatabricks.run_and_record_job(job_id, plan, compute, project["id"])
-    if prediction_id := run_response.result:
+    prediction_id = run_response.result
+    if prediction_id:
         click.echo(f"Prediction ID: {prediction_id}")
     else:
         click.echo(str(run_response.error), err=True)
@@ -77,7 +79,8 @@ def create_prediction(
     prediction_response = awsdatabricks.create_prediction_for_run(
         run_id, plan, compute, project["id"], allow_incomplete
     )
-    if prediction := prediction_response.result:
+    prediction = prediction_response.result
+    if prediction:
         click.echo(f"Prediction ID: {prediction}")
     else:
         click.echo(f"Failed to create prediction. {prediction_response.error}", err=True)
@@ -105,7 +108,8 @@ def get_cluster_report(
 ):
     """Get a cluster report"""
     config_response = awsdatabricks.get_cluster_report(run_id, plan, compute, allow_incomplete)
-    if config := config_response.result:
+    config = config_response.result
+    if config:
         click.echo(
             orjson.dumps(
                 config.dict(exclude_none=True),

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -30,7 +30,8 @@ def run_job_flow(job_flow: TextIOWrapper, project: dict = None, region: str = No
     run_response = awsemr.run_and_record_job_flow(
         job_flow_obj, project["id"] if project else None, region
     )
-    if prediction_id := run_response.result:
+    prediction_id = run_response.result
+    if prediction_id:
         click.echo(f"Run complete. Prediction ID: {prediction_id}")
     else:
         click.echo(str(run_response.error), err=True)
@@ -48,13 +49,14 @@ def run_job_flow(job_flow: TextIOWrapper, project: dict = None, region: str = No
 def run_prediction(prediction_id: str, preference: Preference, region: str = None):
     """Execute a prediction"""
     prediction_response = get_prediction(prediction_id, preference.value)
-
-    if prediction := prediction_response.result:
+    prediction = prediction_response.result
+    if prediction:
         config = prediction["solutions"][preference.value]["configuration"]
 
         if prediction["product_code"] == Platform.AWS_EMR:
             cluster_response = awsemr.run_job_flow(config, prediction.get("project_id"), region)
-            if cluster_id := cluster_response.result:
+            cluster_id = cluster_response.result
+            if cluster_id:
                 click.echo(f"EMR cluster ID: {cluster_id}")
             else:
                 click.echo(str(cluster_response.error), err=True)
@@ -70,7 +72,8 @@ def run_prediction(prediction_id: str, preference: Preference, region: str = Non
 def create_prediction(cluster_id: str, region: str = None):
     """Create prediction for a cluster"""
     prediction_response = awsemr.create_prediction_for_cluster(cluster_id, region)
-    if prediction := prediction_response.result:
+    prediction = prediction_response.result
+    if prediction:
         click.echo(f"Prediction ID: {prediction}")
     else:
         click.echo(f"Failed to create prediction. {prediction_response.error}", err=True)
@@ -83,7 +86,8 @@ def create_prediction(cluster_id: str, region: str = None):
 def create_project_prediction(project: Dict[str, str], run_id: str = None, region: str = None):
     """Create prediction for the latest project cluster or one specified by --run-id"""
     prediction_response = awsemr.create_project_prediction(project["id"], run_id, region)
-    if prediction := prediction_response.result:
+    prediction = prediction_response.result
+    if prediction:
         click.echo(f"Prediction ID: {prediction}")
     else:
         click.echo(f"Failed to create prediction. {prediction_response.error}", err=True)
@@ -95,7 +99,8 @@ def create_project_prediction(project: Dict[str, str], run_id: str = None, regio
 def get_cluster_report(cluster_id: str, region: str = None):
     """Get a cluster report"""
     config_response = awsemr.get_cluster_report(cluster_id, region)
-    if config := config_response.result:
+    config = config_response.result
+    if config:
         click.echo(
             orjson.dumps(
                 config, option=orjson.OPT_INDENT_2 | orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z
@@ -112,7 +117,8 @@ def get_cluster_report(cluster_id: str, region: str = None):
 def record_run(cluster_id: str, project: str, region: str = None):
     """Record a project run"""
     response = awsemr.record_run(cluster_id, project["id"], region)
-    if prediction_id := response.result:
+    prediction_id = response.result
+    if prediction_id:
         click.echo(f"Prediction ID: {prediction_id}")
     else:
         click.echo(str(response.error), err=True)

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -2,6 +2,7 @@ from io import TextIOWrapper
 
 import click
 import orjson
+from typing import Dict
 
 from sync import awsemr
 from sync.api.predictions import get_prediction
@@ -79,7 +80,7 @@ def create_prediction(cluster_id: str, region: str = None):
 @click.argument("project", callback=validate_project)
 @click.option("-r", "--run-id")
 @click.option("-r", "--region")
-def create_project_prediction(project: dict[str, str], run_id: str = None, region: str = None):
+def create_project_prediction(project: Dict[str, str], run_id: str = None, region: str = None):
     """Create prediction for the latest project cluster or one specified by --run-id"""
     prediction_response = awsemr.create_project_prediction(project["id"], run_id, region)
     if prediction := prediction_response.result:

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -1,8 +1,8 @@
 from io import TextIOWrapper
+from typing import Dict
 
 import click
 import orjson
-from typing import Dict
 
 from sync import awsemr
 from sync.api.predictions import get_prediction

--- a/sync/cli/predictions.py
+++ b/sync/cli/predictions.py
@@ -75,11 +75,13 @@ def generate(
                 platform, report, event_log_path.name, event_log_fobj.read(), project["id"]
             )
 
-    if prediction_id := response.result:
+    prediction_id = response.result
+    if prediction_id:
         click.echo(f"Prediction ID: {prediction_id}")
         click.echo("Waiting for result...")
         prediction_response = wait_for_prediction(prediction_id, preference.value)
-        if prediction := prediction_response.result:
+        prediction = prediction_response.result
+        if prediction:
             click.echo(
                 orjson.dumps(
                     prediction,
@@ -134,7 +136,8 @@ def create(ctx: click.Context, platform: Platform, event_log: str, report: str, 
                 platform, report, event_log_path.name, event_log_fobj.read(), project["id"]
             )
 
-    if prediction_id := response.result:
+    prediction_id = response.result
+    if prediction_id:
         click.echo(f"Prediction ID: {prediction_id}")
     else:
         click.echo(str(response.error), err=True)
@@ -177,7 +180,8 @@ def list(platform: Platform, project: dict = None):
     response = get_predictions(
         product=platform.value if platform else None, project_id=project["id"]
     )
-    if predictions := response.result:
+    predictions = response.result
+    if predictions:
         click.echo_via_pager(
             f"{p['created_at']} {p['prediction_id']} ({p.get('project_id', 'not part of a project'):^36}): {p['application_name']}\n"
             for p in predictions

--- a/sync/cli/projects.py
+++ b/sync/cli/projects.py
@@ -24,7 +24,8 @@ def projects():
 def list():
     """List projects"""
     response = get_projects()
-    if projects := response.result:
+    projects = response.result
+    if projects:
         click.echo_via_pager(f"{p['updated_at']} {p['id']}: {p['app_id']}\n" for p in projects)
     else:
         click.echo(str(response.error), err=True)
@@ -37,7 +38,8 @@ def get(project: dict):
 
     PROJECT is either a project ID or application name"""
     response = get_project(project["id"])
-    if project := response.result:
+    project = response.result
+    if project:
         click.echo(
             orjson.dumps(
                 project,
@@ -65,7 +67,8 @@ def create(
 
     APP_ID is a name that uniquely identifies an application"""
     response = create_project(app_id, description, location, preference)
-    if project := response.result:
+    project = response.result
+    if project:
         click.echo(f"Project ID: {project['id']}")
     else:
         click.echo(str(response.error), err=True)
@@ -115,7 +118,8 @@ def delete(project: dict):
 def get_latest_prediction(project: dict, preference: Preference):
     """Get the latest prediction in a project"""
     prediction_response = get_prediction(project["id"], preference)
-    if prediction := prediction_response.result:
+    prediction = prediction_response.result
+    if prediction:
         click.echo(
             orjson.dumps(
                 prediction,

--- a/sync/cli/util.py
+++ b/sync/cli/util.py
@@ -1,9 +1,10 @@
+from typing import Union
 from uuid import UUID
 
 from sync.api.projects import get_project_by_app_id
 
 
-def validate_project(ctx, param, value: str | None) -> dict:
+def validate_project(ctx, param, value: Union[str, None]) -> dict:
     if not value:
         return {"id": None}
 
@@ -12,7 +13,8 @@ def validate_project(ctx, param, value: str | None) -> dict:
         return {"id": value}
     except ValueError:
         project_response = get_project_by_app_id(value)
-        if error := project_response.error:
+        error = project_response.error
+        if error:
             ctx.fail(str(error))
 
         return project_response.result

--- a/sync/clients/__init__.py
+++ b/sync/clients/__init__.py
@@ -1,13 +1,14 @@
 import httpx
 import orjson
 from tenacity import Retrying, TryAgain, stop_after_attempt, wait_exponential_jitter
+from typing import Tuple, Union, Set
 
 from sync import __version__
 
 USER_AGENT = f"Sync Library/{__version__} (syncsparkpy)"
 
 
-def encode_json(obj: dict) -> tuple[dict, str]:
+def encode_json(obj: dict) -> Tuple[dict, str]:
     # "%Y-%m-%dT%H:%M:%SZ"
     options = orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS | orjson.OPT_NAIVE_UTC
 
@@ -24,7 +25,7 @@ class RetryableHTTPClient:
     Smaller wrapper around httpx.Client/AsyncClient to contain retrying logic that httpx does not offer natively
     """
 
-    _DEFAULT_RETRYABLE_STATUS_CODES: set[httpx.codes] = {
+    _DEFAULT_RETRYABLE_STATUS_CODES: Set[httpx.codes] = {
         httpx.codes.REQUEST_TIMEOUT,
         httpx.codes.TOO_EARLY,
         httpx.codes.TOO_MANY_REQUESTS,
@@ -34,8 +35,8 @@ class RetryableHTTPClient:
         httpx.codes.GATEWAY_TIMEOUT,
     }
 
-    def __init__(self, client: httpx.Client | httpx.AsyncClient):
-        self._client: httpx.Client | httpx.AsyncClient = client
+    def __init__(self, client: Union[httpx.Client, httpx.AsyncClient]):
+        self._client: Union[httpx.Client, httpx.AsyncClient] = client
 
     def _send_request(self, request: httpx.Request) -> httpx.Response:
         try:

--- a/sync/clients/databricks.py
+++ b/sync/clients/databricks.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generator
+from typing import Generator, Union
 
 import httpx
 
@@ -113,7 +113,7 @@ class DatabricksClient(RetryableHTTPClient):
         return {"error_code": "UNKNOWN_ERROR", "message": "Transaction failure"}
 
 
-_sync_client: DatabricksClient | None = None
+_sync_client: Union[DatabricksClient, None] = None
 
 
 def get_default_client() -> DatabricksClient:

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generator
+from typing import Generator, List
 
 import httpx
 
@@ -40,7 +40,8 @@ class SyncAuth(httpx.Auth):
             auth = response.json()
             self._access_token = auth["result"]["access_token"]
         elif response.headers.get("Content-Type", "").startswith("application/json"):
-            if error := response.json().get("error"):
+            error = response.json().get("error")
+            if error:
                 logger.error(f"{error['code']}: {error['message']}")
             else:
                 logger.error(f"{response.status_code}: Failed to authenticate")
@@ -77,7 +78,7 @@ class SyncClient(RetryableHTTPClient):
             )
         )
 
-    def get_predictions(self, params: dict = None) -> list[dict]:
+    def get_predictions(self, params: dict = None) -> List[dict]:
         return self._send(
             self._client.build_request("GET", "/v1/autotuner/predictions", params=params)
         )

--- a/sync/config.py
+++ b/sync/config.py
@@ -4,7 +4,7 @@ Utilities providing configuration to the SDK
 
 import json
 from pathlib import Path
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, Dict
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -17,8 +17,8 @@ CONFIG_FILE = "config"
 DATABRICKS_CONFIG_FILE = "databrickscfg"
 
 
-def json_config_settings_source(path: str) -> Callable[[BaseSettings], dict[str, Any]]:
-    def source(settings: BaseSettings) -> dict[str, Any]:
+def json_config_settings_source(path: str) -> Callable[[BaseSettings], Dict[str, Any]]:
+    def source(settings: BaseSettings) -> Dict[str, Any]:
         config_path = _get_config_dir().joinpath(path)
         if config_path.exists():
             with open(config_path) as fobj:

--- a/sync/config.py
+++ b/sync/config.py
@@ -4,7 +4,7 @@ Utilities providing configuration to the SDK
 
 import json
 from pathlib import Path
-from typing import Any, Callable, Union, Dict
+from typing import Any, Callable, Dict, Union
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -39,7 +39,9 @@ class APIKey(BaseSettings):
 
 
 class Configuration(BaseSettings):
-    default_project_url: Union[str, None] = Field(description="default location for Sync project data")
+    default_project_url: Union[str, None] = Field(
+        description="default location for Sync project data"
+    )
     default_prediction_preference: Union[Preference, None] = Preference.BALANCED
     api_url: str = Field("https://api.synccomputing.com", env="SYNC_API_URL")
 

--- a/sync/config.py
+++ b/sync/config.py
@@ -148,30 +148,29 @@ _db_config = None
 
 
 def __getattr__(name):
-    match name:
-        case "CONFIG":
-            global _config
-            if _config is None:
-                _config = Configuration()
-            return _config
-        case "API_KEY":
-            global _api_key
-            if _api_key is None:
-                try:
-                    _api_key = APIKey()
-                except ValueError:
-                    pass
-            return _api_key
-        case "DB_CONFIG":
-            global _db_config
-            if _db_config is None:
-                try:
-                    _db_config = DatabricksConf()
-                except ValueError:
-                    pass
-            return _db_config
-
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+    if name == "CONFIG":
+        global _config
+        if _config is None:
+            _config = Configuration()
+        return _config
+    elif name == "API_KEY":
+        global _api_key
+        if _api_key is None:
+            try:
+                _api_key = APIKey()
+            except ValueError:
+                pass
+        return _api_key
+    elif name == "DB_CONFIG":
+        global _db_config
+        if _db_config is None:
+            try:
+                _db_config = DatabricksConf()
+            except ValueError:
+                pass
+        return _db_config
+    else:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
 def _get_config_dir() -> Path:

--- a/sync/config.py
+++ b/sync/config.py
@@ -4,7 +4,7 @@ Utilities providing configuration to the SDK
 
 import json
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Union
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -39,8 +39,8 @@ class APIKey(BaseSettings):
 
 
 class Configuration(BaseSettings):
-    default_project_url: str | None = Field(description="default location for Sync project data")
-    default_prediction_preference: Preference | None = Preference.BALANCED
+    default_project_url: Union[str, None] = Field(description="default location for Sync project data")
+    default_prediction_preference: Union[Preference, None] = Preference.BALANCED
     api_url: str = Field("https://api.synccomputing.com", env="SYNC_API_URL")
 
     @validator("default_project_url")

--- a/sync/models.py
+++ b/sync/models.py
@@ -3,7 +3,7 @@ Models used throughout this SDK
 """
 
 from enum import Enum, unique
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Union
 
 from pydantic import BaseModel, Field, root_validator, validator
 from pydantic.generics import GenericModel
@@ -27,9 +27,9 @@ class Project(BaseModel):
         ...,
         description="a string that uniquely identifies an application to the owner of that application",
     )
-    description: str | None = Field(description="Additional information on the app, or project")
-    s3_url: str | None = Field(description="location of data from runs of the application")
-    prediction_preference: Preference | None = Field(description="preferred prediction to apply")
+    description: Union[str, None] = Field(description="Additional information on the app, or project")
+    s3_url: Union[str, None] = Field(description="location of data from runs of the application")
+    prediction_preference: Union[Preference, None] = Field(description="preferred prediction to apply")
 
 
 class Error(BaseModel):
@@ -92,8 +92,8 @@ DataType = TypeVar("DataType")
 
 
 class Response(GenericModel, Generic[DataType]):
-    result: DataType | None
-    error: Error | None
+    result: Union[DataType, None]
+    error: Union[Error, None]
 
     @validator("error", always=True)
     def check_consistency(cls, err, values):

--- a/sync/models.py
+++ b/sync/models.py
@@ -71,7 +71,7 @@ class DatabricksClusterReport(BaseModel):
     compute_type: DatabricksComputeType
     cluster: dict
     cluster_events: dict
-    instances: dict
+    instances: Union[dict, None]
 
 
 class DatabricksError(Error):

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -630,7 +630,6 @@ def test_create_prediction_for_run_success(respx_mock):
         mock_aws_client.side_effect = client_patch
         result = create_prediction_for_run("75778", "Premium", "Jobs Compute", "my-project-id")
 
-    assert not result.error
     assert result.result
 
 
@@ -728,7 +727,6 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
         mock_aws_client.side_effect = client_patch
         result = create_prediction_for_run("75778", "Premium", "Jobs Compute", "my-project-id")
 
-    assert not result.error
     assert result.result
 
 
@@ -810,7 +808,6 @@ def test_create_prediction_for_run_with_pending_task(respx_mock):
             "75778", "Premium", "Jobs Compute", "my-project-id", exclude_tasks=["sync_task"]
         )
 
-    assert not result.error
     assert result.result
 
 
@@ -949,5 +946,4 @@ def test_create_prediction_for_run_event_log_upload_delay(
         mock_aws_client.side_effect = client_patch
         result = create_prediction_for_run("75778", "Premium", "Jobs Compute", "my-project-id")
 
-    assert not result.error
     assert result.result

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -533,11 +533,10 @@ def test_create_prediction_for_run_no_instances_found(respx_mock):
     s3_stubber.add_client_error("get_object", "NoSuchKey")
 
     def client_patch(name, **kwargs):
-        match name:
-            case "ec2":
-                return ec2
-            case "s3":
-                return s3
+        if name == "ec2":
+            return ec2
+        elif name == "s3":
+            return s3
 
     with s3_stubber, ec2_stubber, patch("boto3.client") as mock_aws_client:
         mock_aws_client.side_effect = client_patch
@@ -622,11 +621,10 @@ def test_create_prediction_for_run_success(respx_mock):
     )
 
     def client_patch(name, **kwargs):
-        match name:
-            case "s3":
-                return s3
-            case "ec2":
-                return ec2
+        if name == "ec2":
+            return ec2
+        elif name == "s3":
+            return s3
 
     with s3_stubber, ec2_stubber, patch("boto3.client") as mock_aws_client:
         mock_aws_client.side_effect = client_patch
@@ -721,11 +719,10 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
     )
 
     def client_patch(name, **kwargs):
-        match name:
-            case "s3":
-                return s3
-            case "ec2":
-                return ec2
+        if name == "ec2":
+            return ec2
+        elif name == "s3":
+            return s3
 
     with s3_stubber, ec2_stubber, patch("boto3.client") as mock_aws_client:
         mock_aws_client.side_effect = client_patch
@@ -802,11 +799,10 @@ def test_create_prediction_for_run_with_pending_task(respx_mock):
     )
 
     def client_patch(name, **kwargs):
-        match name:
-            case "s3":
-                return s3
-            case "ec2":
-                return ec2
+        if name == "ec2":
+            return ec2
+        elif name == "s3":
+            return s3
 
     with s3_stubber, ec2_stubber, patch("boto3.client") as mock_aws_client:
         mock_aws_client.side_effect = client_patch
@@ -944,11 +940,10 @@ def test_create_prediction_for_run_event_log_upload_delay(
     )
 
     def client_patch(name, **kwargs):
-        match name:
-            case "s3":
-                return s3
-            case "ec2":
-                return ec2
+        if name == "ec2":
+            return ec2
+        elif name == "s3":
+            return s3
 
     with s3_stubber, ec2_stubber, patch("boto3.client") as mock_aws_client:
         mock_aws_client.side_effect = client_patch

--- a/tests/test_awsemr.py
+++ b/tests/test_awsemr.py
@@ -184,11 +184,10 @@ def test_get_project_report(get_project, get_cluster_report):
     )
 
     def client_patch(name, **kwargs):
-        match name:
-            case "s3":
-                return s3
-            case "emr":
-                return emr
+        if name == "s3":
+            return s3
+        elif name == "emr":
+            return emr
 
     with s3_stubber, emr_stubber, patch("boto3.client") as mock_client:
         mock_client.side_effect = client_patch


### PR DESCRIPTION
[PROD-820 Expand supported the library's Python versions to [3.7,3.11]](https://synccomputing.atlassian.net/browse/PROD-820?atlOrigin=eyJpIjoiOTIwMmJmMGFjMTc2NDdlOWIzN2QyMWUyNjdkOTMxNzMiLCJwIjoiaiJ9)

In support of running this library in customer environments, this drops the minimum supported Python version down to 3.7.x

Initially submitting this PR against the `init_scripts` branch in order to get a clean diff, but I can update the target branch to `main` once #22 is approved + merged


The main changes in this PR include -

- Changing `match` statements to `if/elif/else` chains,
- `dict`/`list`/`tuple` generic type-hints to `typing.Dict`/`List`/`Tuple`
- `Union | Types` --> `typing.Union[...]`
- Changing assignment expressions -
```python
if foo := m.get("bar"):
  ...
```
 to -
```python
foo = m.get("bar")
if foo:
  ...
```