### PR TITLE
Change python version in GH actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.7.x
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7.5"
+          python-version: "3.7.16"
 
       - name: Install dependencies
         run: pip install .[dev]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.7.16"
       - name: Install dependencies
         run: pip install .
       - name: version-tag
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7.5"
+          python-version: "3.7.16"
       - name: Install dependencies
         run: pip install .[dev]
       - name: Build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write   # To allow pushing tags/etc.
 
     # Specify runner + deployment step
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +51,7 @@ jobs:
     needs: release-latest
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -85,7 +85,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     # Specify runner + deployment step
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/demo/install_cli.sh
+++ b/demo/install_cli.sh
@@ -18,7 +18,7 @@ function install_sync() {
   local SYNC_PYTHON="$(find_python)"
 
   if [[ -z $SYNC_PYTHON ]]; then
-    >&2 echo "Python 3.10 is required"
+    >&2 echo "Python 3.7+ is required"
     return 1
   fi
 

--- a/docs/guide/start.rst
+++ b/docs/guide/start.rst
@@ -5,7 +5,7 @@ Requirements
 ------------
 
 1. Currently only linux-based systems are supported.
-2. Python 3.10.x
+2. Python 3.7.x and above
 
 Installation
 ------------
@@ -14,7 +14,7 @@ Install this library and CLI the same way you'd install a Python package. With a
 
 .. code-block:: shell
 
-  pip install https://github.com/synccomputingcode/syncsparkpy/archive/main.tar.gz
+  pip install https://github.com/synccomputingcode/syncsparkpy/archive/latest.tar.gz
 
 Configuration
 -------------


### PR DESCRIPTION
`3.7.5` is not compatible with Ubuntu 22.04, but `3.7.16` is. Changes from `3.7.5` to `3.7.16` are just security patches, so there is no real functional impact to us.