### PR TITLE
[PROD-1062] Add support for getting the event log from DBFS

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/clients/databricks.py
+++ b/sync/clients/databricks.py
@@ -113,6 +113,30 @@ class DatabricksClient(RetryableHTTPClient):
             )
         )
 
+    def open_dbfs_file_stream(self, path: str, overwrite: bool = False) -> dict:
+        headers, content = encode_json({"path": path, "overwrite": overwrite})
+        return self._send(
+            self._client.build_request(
+                "POST", "/api/2.0/dbfs/create", headers=headers, content=content
+            )
+        )
+
+    def add_block_to_dbfs_file_stream(self, handle: int, data: str) -> dict:
+        headers, content = encode_json({"handle": handle, "data": data})
+        return self._send(
+            self._client.build_request(
+                "POST", "/api/2.0/dbfs/add-block", headers=headers, content=content
+            )
+        )
+
+    def close_dbfs_file_stream(self, handle: int) -> dict:
+        headers, content = encode_json({"handle": handle})
+        return self._send(
+            self._client.build_request(
+                "POST", "/api/2.0/dbfs/close", headers=headers, content=content
+            )
+        )
+
     def _send(self, request: httpx.Request) -> dict:
         response = self._send_request(request)
 

--- a/sync/utils/dbfs.py
+++ b/sync/utils/dbfs.py
@@ -1,0 +1,41 @@
+import base64
+
+from sync.clients.databricks import DatabricksClient, get_default_client
+
+
+def format_dbfs_filepath(base_path: str):
+    base_path = base_path.strip("/")
+    return f"dbfs:/{base_path}" if "dbfs:/" not in base_path else base_path
+
+
+def read_dbfs_file(
+    filepath: str, filesize: int = None, dbx_client: DatabricksClient = get_default_client()
+) -> bytes:
+    """Given a DBFS filepath, returns that file's content in its entirety"""
+    offset = 0
+    filepath = format_dbfs_filepath(filepath)
+
+    if filesize is not None:
+        bytes_read = 0
+        # DBFS tells us exactly how many bytes to expect for each file, so if that size is known,
+        #  we can pre-allocate an array to write the file chunks in to
+        file_content = bytearray(filesize)
+        while bytes_read < filesize:
+            chunk = dbx_client.read_dbfs_file_chunk(filepath, offset=bytes_read)
+            new_bytes_read = bytes_read + chunk["bytes_read"]
+            file_content[bytes_read:new_bytes_read] = base64.b64decode(chunk["data"])
+            bytes_read = new_bytes_read
+    else:
+        file_content = ""
+        chunk = dbx_client.read_dbfs_file_chunk(filepath, offset)
+        bytes_read = chunk["bytes_read"]
+        while bytes_read > 0:
+            file_content += chunk["data"]
+            offset += bytes_read
+
+            chunk = dbx_client.read_dbfs_file_chunk(filepath, offset)
+            bytes_read = chunk["bytes_read"]
+
+        file_content = base64.b64decode(file_content)
+
+    return file_content

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -670,7 +670,9 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
 
     base_prefix = "path/to/logs/0101-214342-tpi6qdp2"
     eventlog_file_prefix = f"{base_prefix}/eventlog/0101-214342-tpi6qdp2"
-    cluster_instances_file_key = f"{base_prefix}/sync_data/cluster_instances.json"
+    cluster_instances_file_key = (
+        f"{base_prefix}/sync_data/1443449481634833945/cluster_instances.json"
+    )
 
     # Don't add any responses for this one as we expect all the instance data we need to be available
     #  in the cluster_instances.json file


### PR DESCRIPTION
[PROD-1062](https://synccomputing.atlassian.net/browse/PROD-1062?atlOrigin=eyJpIjoiOTFlN2UxMzIzYjc3NGI5Zjk2NzI5Y2ZkMGRjYjFmMzciLCJwIjoiaiJ9)

Adds support in `awsdatabricks.monitor_cluster` for saving state to DBFS, and also adds support in `awsdatabricks._get_cluster_instances` for reading back the file saved in DBFS.

[PROD-1062]: https://synccomputing.atlassian.net/browse/PROD-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ