### PR TITLE
[PROD-1104] Use project name instead of app_id

### DIFF
--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -38,16 +38,17 @@ def get_prediction(project_id: str, preference: Preference = None) -> Response[d
 
 
 def create_project(
-    app_id: str,
+    name: str,
     description: str = None,
     s3_url: str = None,
     prediction_preference: Preference = Preference.ECONOMY,
     prediction_params: dict = None,
+    app_id: str = None,
 ) -> Response[dict]:
     """Creates a Sync project for tracking and optimizing Apache Spark applications
 
-    :param app_id: Apache Spark application name
-    :type app_id: str
+    :param name: Project name
+    :type name: str
     :param description: application description, defaults to None
     :type description: str, optional
     :param s3_url: S3 URL under which to store project configurations and logs, defaults to None
@@ -55,18 +56,21 @@ def create_project(
     :param prediction_preference: preferred prediction solution, defaults to `Preference.ECONOMY`
     :type prediction_preference: Preference, optional
     :param prediction_params: dictionary of prediction parameters, defaults to None. Valid options are documented here - https://developers.synccomputing.com/reference/create_project_v1_projects_post
-    :type prediction_preference: dict, optional
+    :type prediction_params: dict, optional
+    :param app_id: Apache Spark application identifier, defaults to None
+    :type app_id: str, optional
     :return: the newly created project
     :rtype: Response[dict]
     """
     return Response(
         **get_default_client().create_project(
             {
-                "app_id": app_id,
+                "name": name,
                 "description": description,
                 "s3_url": s3_url,
                 "prediction_preference": prediction_preference,
                 "prediction_params": prediction_params,
+                "app_id": app_id,
             }
         )
     )

--- a/sync/cli/projects.py
+++ b/sync/cli/projects.py
@@ -26,7 +26,7 @@ def list():
     response = get_projects()
     projects = response.result
     if projects:
-        click.echo_via_pager(f"{p['updated_at']} {p['id']}: {p['app_id']}\n" for p in projects)
+        click.echo_via_pager(f"{p['updated_at']} {p['id']}: {p['name']}\n" for p in projects)
     else:
         click.echo(str(response.error), err=True)
 
@@ -51,7 +51,7 @@ def get(project: dict):
 
 
 @projects.command
-@click.argument("app-id")
+@click.argument("name")
 @click.option("-d", "--description")
 @click.option("-l", "--location", help="S3 URL under which to store event logs and configuration")
 @click.option(
@@ -60,13 +60,26 @@ def get(project: dict):
     type=click.Choice(Preference),
     default=CONFIG.default_prediction_preference,
 )
+@click.option(
+    "-i", "--app-id", help="External identifier often based on the project's target application"
+)
 def create(
-    app_id: str, description: str = None, location: str = None, preference: Preference = None
+    name: str,
+    description: str = None,
+    location: str = None,
+    preference: Preference = None,
+    app_id: str = None,
 ):
     """Create a project
 
     APP_ID is a name that uniquely identifies an application"""
-    response = create_project(app_id, description, location, preference)
+    response = create_project(
+        name,
+        description=description,
+        s3_url=location,
+        prediction_preference=preference,
+        app_id=app_id,
+    )
     project = response.result
     if project:
         click.echo(f"Project ID: {project['id']}")

--- a/sync/models.py
+++ b/sync/models.py
@@ -23,13 +23,17 @@ class Platform(str, Enum):
 
 class Project(BaseModel):
     id: UUID4 = Field(..., description="project UUID")
-    app_id: str = Field(
-        ...,
-        description="a string that uniquely identifies an application to the owner of that application",
+    name: str = Field(..., description="project name")
+    description: Union[str, None] = Field(
+        description="additional information on the app, or project"
     )
-    description: Union[str, None] = Field(description="Additional information on the app, or project")
     s3_url: Union[str, None] = Field(description="location of data from runs of the application")
-    prediction_preference: Union[Preference, None] = Field(description="preferred prediction to apply")
+    prediction_preference: Union[Preference, None] = Field(
+        description="preferred prediction to apply"
+    )
+    app_id: str = Field(
+        ..., description="external identifier, often based on the project's target application"
+    )
 
 
 class Error(BaseModel):

--- a/tests/test_awsemr.py
+++ b/tests/test_awsemr.py
@@ -111,7 +111,7 @@ def test_get_project_report(get_project, get_cluster_report):
             "created_at": "2023-01-20T00:38:10Z",
             "updated_at": "2023-03-10T17:18:50Z",
             "id": "4f5fe783-df74-4d64-adad-a635d6319579",
-            "app_id": "Data Insights",
+            "name": "Data Insights",
             "description": "My first project",
             "s3_url": "s3://megacorp-bucket/projects/emr",
             "prediction_preference": "balanced",


### PR DESCRIPTION
https://synccomputing.atlassian.net/browse/PROD-1104

This should be released after the corresponding backend changes.

1. Requires `name` instead of `app_id` when creating projects
2. Adds support for optional `job_id` project attribute
3. Fixes documentation bug:
   <img width="976" alt="Screenshot 2023-06-20 at 4 59 11 PM" src="https://github.com/synccomputingcode/syncsparkpy/assets/5589236/8f3c857b-7e06-4f3f-af86-85ac1e7f77f8">