### PR TITLE
Handle exhausting the next Markers for emr.list_instances/steps calls when generating an EMR cluster report

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
Should fix cluster report generation issues as discussed in - https://sync-computing.slack.com/archives/C03H8ERUPNY/p1690554169307939?thread_ts=1690553934.714369&cid=C03H8ERUPNY