### PR TITLE
add ebs volume info to the cluster report

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -223,7 +223,7 @@ def _get_cluster_report(
     raise NotImplementedError()
 
 
-def _get_cluster_instances_from_dbfs(filepath: str):
+def _get_aws_cluster_info_from_dbfs(filepath: str):
     filepath = format_dbfs_filepath(filepath)
     dbx_client = get_default_client()
     try:

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -223,7 +223,7 @@ def _get_cluster_report(
     raise NotImplementedError()
 
 
-def _get_aws_cluster_info_from_dbfs(filepath: str):
+def _get_cluster_instances_from_dbfs(filepath: str):
     filepath = format_dbfs_filepath(filepath)
     dbx_client = get_default_client()
     try:

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -29,6 +29,7 @@ def create_prediction(
     cluster: dict,
     cluster_events: dict,
     instances: dict,
+    volumes: dict,
     eventlog: bytes,
     project_id: str = None,
 ) -> Response[str]:
@@ -68,6 +69,7 @@ def create_prediction(
             "cluster": cluster,
             "cluster_events": cluster_events,
             "instances": instances,
+            "volumes": volumes,
         },
         "eventlog.zip",
         eventlog,
@@ -167,6 +169,7 @@ def create_prediction_for_run(
                     cluster=cluster,
                     cluster_events=cluster_report.cluster_events,
                     instances=cluster_report.instances,
+                    volumes=cluster_report.volumes,
                     eventlog=eventlog,
                     project_id=project_id,
                 )

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -254,9 +254,7 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
         ec2 = boto.client("ec2", region_name=aws_region_name)
         try:
             cluster_instances = _get_ec2_instances(cluster_id, ec2)
-
-            if cluster_instances:
-                cluster_instances["Volumes"] = _get_ebs_volumes(cluster_id, ec2)
+            cluster_instances["Volumes"] = _get_ebs_volumes(cluster_id, ec2)
 
         except Exception as exc:
             logger.warning(exc)

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -412,10 +412,10 @@ def _get_ebs_volumes(cluster_id: str, ec2_client: "botocore.client.ec2") -> list
             **args,
         )
 
-        if new_volumes := response.get("Volumes"):
-            volumes += new_volumes
+        volumes += response.get("Volumes", [])
 
-        if next_token := response.get("NextToken"):
+        next_token = response.get("NextToken")
+        if next_token:
             args["NextToken"] = next_token
         else:
             break
@@ -436,10 +436,10 @@ def _get_ec2_instances(cluster_id: str, ec2_client: "botocore.client.ec2") -> di
             **args,
         )
 
-        if new_instances := response.get("Reservations"):
-            instances += new_instances
+        instances += response.get("Reservations", [])
 
-        if next_token := response.get("NextToken"):
+        next_token = response.get("NextToken")
+        if next_token:
             args["NextToken"] = next_token
         else:
             break

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -285,15 +285,8 @@ def _get_aws_cluster_info_from_s3(bucket: str, file_key: str, cluster_id):
     s3 = boto.client("s3")
     try:
         return s3.get_object(Bucket=bucket, Key=file_key)["Body"].read()
-    except ClientError as ex:
-        if ex.response["Error"]["Code"] == "NoSuchKey":
-            logger.warning(
-                f"Could not find sync_data/aws_cluster_info.json for cluster: {cluster_id}"
-            )
-        else:
-            logger.error(
-                f"Unexpected error encountered while attempting to fetch sync_data/aws_cluster_info.json: {ex}"
-            )
+    except ClientError as err:
+        logger.warning(f"Failed to retrieve cluster info from S3 with key, '{file_key}': {err}")
 
 
 def monitor_cluster(cluster_id: str, polling_period: int = 30) -> None:

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -436,8 +436,6 @@ def _get_ec2_instances(cluster_id: str, ec2_client: "botocore.client.ec2") -> di
             **args,
         )
 
-        print(response)
-
         if new_instances := response.get("Reservations"):
             instances += new_instances
 

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -1,5 +1,6 @@
 import logging
 from time import sleep
+from typing import Dict, List
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -399,7 +400,7 @@ def _monitor_cluster(  # noqa: C901
         sleep(polling_period)
 
 
-def _get_ebs_volumes(cluster_id: str, ec2_client: "botocore.client.ec2") -> list[dict]:
+def _get_ebs_volumes(cluster_id: str, ec2_client: "botocore.client.ec2") -> List[Dict]:
 
     args = {}
     volumes = []
@@ -423,7 +424,7 @@ def _get_ebs_volumes(cluster_id: str, ec2_client: "botocore.client.ec2") -> list
     return volumes
 
 
-def _get_ec2_instances(cluster_id: str, ec2_client: "botocore.client.ec2") -> dict[str, list]:
+def _get_ec2_instances(cluster_id: str, ec2_client: "botocore.client.ec2") -> Dict[str, List[Dict]]:
 
     args = {}
     instances = []

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -12,7 +12,7 @@ import sync._databricks
 from sync._databricks import (
     _cluster_log_destination,
     _get_all_cluster_events,
-    _get_aws_cluster_info_from_dbfs,
+    _get_cluster_instances_from_dbfs,
     _wait_for_cluster_termination,
     create_and_record_run,
     create_and_wait_for_run,
@@ -240,7 +240,7 @@ def _get_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict]
                 bucket, cluster_info_file_key, cluster_id
             )
         elif filesystem == "dbfs":
-            cluster_info_file_response = _get_aws_cluster_info_from_dbfs(cluster_info_file_key)
+            cluster_info_file_response = _get_cluster_instances_from_dbfs(cluster_info_file_key)
 
         cluster_info = (
             orjson.loads(cluster_info_file_response) if cluster_info_file_response else None

--- a/sync/models.py
+++ b/sync/models.py
@@ -105,7 +105,7 @@ class DatabricksClusterReport(BaseModel):
 
 class AWSDatabricksClusterReport(DatabricksClusterReport):
     instances: Union[dict, None]
-    volumes: Union[List[dict], None]
+    volumes: Union[dict, None]
 
 
 class AzureDatabricksClusterReport(DatabricksClusterReport):

--- a/sync/models.py
+++ b/sync/models.py
@@ -105,6 +105,7 @@ class DatabricksClusterReport(BaseModel):
 
 class AWSDatabricksClusterReport(DatabricksClusterReport):
     instances: Union[dict, None]
+    volumes: Union[List[dict], None]
 
 
 class AzureDatabricksClusterReport(DatabricksClusterReport):

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -791,9 +791,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
 
     base_prefix = "path/to/logs/0101-214342-tpi6qdp2"
     eventlog_file_prefix = f"{base_prefix}/eventlog/0101-214342-tpi6qdp2"
-    cluster_instances_file_key = (
-        f"{base_prefix}/sync_data/1443449481634833945/cluster_instances.json"
-    )
+    cluster_info_file_key = f"{base_prefix}/sync_data/1443449481634833945/aws_cluster_info.json"
 
     # Don't add any responses for this one as we expect all the instance data we need to be available
     #  in the cluster_instances.json file
@@ -803,7 +801,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
     s3 = boto.client("s3")
     s3_stubber = Stubber(s3)
 
-    mock_instances_bytes = orjson.dumps(
+    mock_cluster_info_bytes = orjson.dumps(
         {**MOCK_INSTANCES, **MOCK_VOLUMES},
         option=orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS | orjson.OPT_NAIVE_UTC,
     )
@@ -811,13 +809,13 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
         "get_object",
         {
             "ContentType": "application/octet-stream",
-            "ContentLength": len(mock_instances_bytes),
+            "ContentLength": len(mock_cluster_info_bytes),
             "Body": StreamingBody(
-                io.BytesIO(mock_instances_bytes),
-                len(mock_instances_bytes),
+                io.BytesIO(mock_cluster_info_bytes),
+                len(mock_cluster_info_bytes),
             ),
         },
-        {"Bucket": "bucket", "Key": cluster_instances_file_key},
+        {"Bucket": "bucket", "Key": cluster_info_file_key},
     )
     s3_stubber.add_response(
         "list_objects_v2",


### PR DESCRIPTION
Add ebs volume information to the cluster report. Information is gathered via the `describe_volumes` call. This is necessary because the `describe_instances` call does not provide comprehensive information about any attached ebs storage, including the storage type, IOPS, and throughput.

To enable reusing most of the existing code without refactor I added the list of volumes as an attribute in the `instances` dict. I considered break this dict apart in the cluster report for a sense of "separation of duties", but I wasn't sure if that was any better. For example:
```
class AWSDatabricksClusterReport(DatabricksClusterReport):
    instances: Union[dict, None]
    volumes: Union[dict, None] #  <--- new field for volumes?
```