### PR TITLE
Graham/create submissions

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 import boto3 as boto
 
 from sync.api.predictions import create_prediction_with_eventlog_bytes, get_prediction
-from sync.api.projects import get_project
+from sync.api.projects import create_project_submission_with_eventlog_bytes, get_project
 from sync.clients.databricks import get_default_client
 from sync.config import CONFIG
 from sync.models import DatabricksAPIError, DatabricksClusterReport, DatabricksError, Response
@@ -134,16 +134,148 @@ def create_prediction_for_run(
     :return: prediction ID
     :rtype: Response[str]
     """
+    run_information_response = _get_run_information(
+        run_id,
+        plan_type,
+        compute_type,
+        project_id,
+        allow_incomplete_cluster_report,
+        exclude_tasks,
+    )
+
+    if run_information_response.error:
+        return run_information_response
+
+    cluster_report, eventlog = run_information_response.result
+
+    return create_prediction(
+        plan_type=cluster_report.plan_type.value,
+        compute_type=cluster_report.compute_type.value,
+        cluster=cluster_report.cluster,
+        cluster_events=cluster_report.cluster_events,
+        instances=cluster_report.instances,
+        eventlog=eventlog,
+        project_id=project_id,
+    )
+
+
+def create_submission(
+    plan_type: str,
+    compute_type: str,
+    project_id: str,
+    cluster: dict,
+    cluster_events: dict,
+    instances: dict,
+    eventlog: bytes,
+) -> Response[str]:
+    """Create a Databricks Project submission
+
+    :param plan_type: either "Standard", "Premium" or "Enterprise"
+    :type plan_type: str
+    :param compute_type: e.g. "Jobs Compute"
+    :type compute_type: str
+    :param cluster: The Databricks cluster definition as defined by -
+        https://docs.databricks.com/dev-tools/api/latest/clusters.html#get
+    :type cluster: dict
+    :param cluster_events: All events, including paginated events, for the cluster as defined by -
+        https://docs.databricks.com/dev-tools/api/latest/clusters.html#events
+        If the cluster is a long-running cluster, this should only include events relevant to the time window that a
+        run occurred in.
+    :type cluster_events: dict
+    :param instances: All EC2 Instances that were a part of the cluster. Expects a data format as is returned by
+        `boto3's EC2.describe_instances API <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_instances.html>`_
+        Instances should be narrowed to just those instances relevant to the Databricks Run. This can be done by passing
+        a `tag:ClusterId` filter to the describe_instances call like -
+        ``Filters=[{"Name": "tag:ClusterId", "Values": ["my-dbx-clusterid"]}]``
+        If there are multiple pages of instances, all pages should be accumulated into 1 dictionary and passed to this
+        function
+    :param eventlog: encoded event log zip
+    :type eventlog: bytes
+    :param project_id: Sync project ID, defaults to None
+    :type project_id: str, optional
+    :return: prediction ID
+    :rtype: Response[str]
+    """
+    return create_project_submission_with_eventlog_bytes(
+        get_default_client().get_platform(),
+        {
+            "plan_type": plan_type,
+            "compute_type": compute_type,
+            "cluster": cluster,
+            "cluster_events": cluster_events,
+            "instances": instances,
+        },
+        "eventlog.zip",
+        eventlog,
+        project_id,
+    )
+
+
+def create_submission_for_run(
+    run_id: str,
+    plan_type: str,
+    compute_type: str,
+    project_id: str,
+    allow_incomplete_cluster_report: bool = False,
+    exclude_tasks: Union[Collection[str], None] = None,
+) -> Response[str]:
+    """Create a Submission for the specified Databricks run.
+
+    :param run_id: Databricks run ID
+    :type run_id: str
+    :param plan_type: either "Standard", "Premium" or "Enterprise"
+    :type plan_type: str
+    :param compute_type: e.g. "Jobs Compute"
+    :type compute_type: str
+    :param project_id: Sync project ID, defaults to None
+    :type project_id: str, optional
+    :param allow_incomplete_cluster_report: Whether creating a prediction with incomplete cluster report data should be allowable
+    :type allow_incomplete_cluster_report: bool, optional, defaults to False
+    :param exclude_tasks: Keys of tasks (task names) to exclude from the prediction
+    :type exclude_tasks: Collection[str], optional, defaults to None
+    :return: prediction ID
+    :rtype: Response[str]
+    """
+    run_information_response = _get_run_information(
+        run_id,
+        plan_type,
+        compute_type,
+        project_id,
+        allow_incomplete_cluster_report,
+        exclude_tasks,
+    )
+
+    if run_information_response.error:
+        return run_information_response
+
+    cluster_report, eventlog = run_information_response.result
+
+    # print(cluster_report)
+
+    return create_submission(
+        plan_type=plan_type,
+        compute_type=compute_type,
+        project_id=project_id,
+        cluster=cluster_report.cluster,
+        cluster_events=cluster_report.cluster_events,
+        instances=cluster_report.instances,
+        eventlog=eventlog,
+    )
+
+
+def _get_run_information(
+    run_id: str,
+    plan_type: str,
+    compute_type: str,
+    project_id: str = None,
+    allow_incomplete_cluster_report: bool = False,
+    exclude_tasks: Union[Collection[str], None] = None,
+) -> Response[Tuple[DatabricksClusterReport, bytes]]:
     run = get_default_client().get_run(run_id)
     if "error_code" in run:
         return Response(error=DatabricksAPIError(**run))
 
-    tasks = [
-        task for task in run["tasks"] if not exclude_tasks or task["task_key"] not in exclude_tasks
-    ]
-
-    if any(task["state"].get("result_state") != "SUCCESS" for task in tasks):
-        return Response(error=DatabricksError(message="Tasks did not complete successfully"))
+    tasks = _filter_run_tasks(run["tasks"], exclude_tasks, project_id)
 
     cluster_id_response = _get_run_cluster_id(tasks)
     cluster_id = cluster_id_response.result
@@ -152,7 +284,7 @@ def create_prediction_for_run(
         # Making these calls prior to fetching the event log allows Databricks a little extra time to finish
         #  uploading all the event log data before we start checking for it
         cluster_report_response = _get_cluster_report(
-            cluster_id, plan_type, compute_type, allow_incomplete_cluster_report
+            cluster_id, tasks, plan_type, compute_type, allow_incomplete_cluster_report
         )
         cluster_report = cluster_report_response.result
         if cluster_report:
@@ -163,16 +295,8 @@ def create_prediction_for_run(
 
             eventlog = eventlog_response.result
             if eventlog:
-                return create_prediction(
-                    plan_type=cluster_report.plan_type.value,
-                    compute_type=cluster_report.compute_type.value,
-                    cluster=cluster,
-                    cluster_events=cluster_report.cluster_events,
-                    instances=cluster_report.instances,
-                    volumes=cluster_report.volumes,
-                    eventlog=eventlog,
-                    project_id=project_id,
-                )
+                # TODO - allow submissions w/out eventlog. Best way to make eventlog optional?..
+                return Response(result=(cluster_report, eventlog))
 
             return eventlog_response
         return cluster_report_response
@@ -183,6 +307,7 @@ def get_cluster_report(
     run_id: str,
     plan_type: str,
     compute_type: str,
+    project_id: str = None,
     allow_incomplete: bool = False,
     exclude_tasks: Union[Collection[str], None] = None,
 ) -> Response[DatabricksClusterReport]:
@@ -194,6 +319,8 @@ def get_cluster_report(
     :type plan_type: str
     :param compute_type: Cluster compute type, e.g. "Jobs Compute"
     :type compute_type: str
+    :param project_id: TODO
+    :type project_id: TODO
     :param allow_incomplete: Whether creating a cluster report with incomplete data should be allowable
     :type allow_incomplete: bool, optional, defaults to False
     :param exclude_tasks: Keys of tasks (task names) to exclude from the report
@@ -205,23 +332,22 @@ def get_cluster_report(
     if "error_code" in run:
         return Response(error=DatabricksAPIError(**run))
 
-    tasks = [
-        task for task in run["tasks"] if not exclude_tasks or task["task_key"] not in exclude_tasks
-    ]
-
-    if any(task["state"].get("result_state") != "SUCCESS" for task in tasks):
-        return Response(error=DatabricksError(message="Tasks did not complete successfully"))
+    tasks = _filter_run_tasks(run["tasks"], exclude_tasks, project_id)
 
     cluster_id_response = _get_run_cluster_id(tasks)
     cluster_id = cluster_id_response.result
     if cluster_id:
-        return _get_cluster_report(cluster_id, plan_type, compute_type, allow_incomplete)
+        return _get_cluster_report(cluster_id, tasks, plan_type, compute_type, allow_incomplete)
 
     return cluster_id_response
 
 
 def _get_cluster_report(
-    cluster_id: str, plan_type: str, compute_type: str, allow_incomplete: bool
+    cluster_id: str,
+    cluster_tasks: List[dict],
+    plan_type: str,
+    compute_type: str,
+    allow_incomplete: bool,
 ) -> Response[DatabricksClusterReport]:
     raise NotImplementedError()
 
@@ -887,10 +1013,33 @@ def _get_job_cluster(tasks: List[dict], job_clusters: list) -> Response[dict]:
     return Response(error=DatabricksError(message="Not all tasks use the same cluster"))
 
 
+def _filter_run_tasks(
+    all_tasks: List[dict],
+    exclude_tasks: Union[Collection[str], None] = None,
+    project_id: str = None,
+):
+    tasks = [
+        task for task in all_tasks if not exclude_tasks or task["task_key"] not in exclude_tasks
+    ]
+    if project_id:
+        project_tasks = [
+            t
+            for t in tasks
+            if t.get("new_cluster", {}).get("custom_tags", {}).get("sync:project-id") == project_id
+        ]
+        if project_tasks:
+            tasks = project_tasks
+        else:
+            logger.warning(
+                f"No task clusters found matching the provided project-id - assuming all non-excluded tasks are relevant"
+            )
+
+    return tasks
+
+
 def _get_run_cluster_id(tasks: List[dict]) -> Response[str]:
     cluster_ids = {task["cluster_instance"]["cluster_id"] for task in tasks}
     num_ids = len(cluster_ids)
-
     if num_ids == 1:
         return Response(result=cluster_ids.pop())
     elif num_ids == 0:

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -6,6 +6,7 @@ import io
 import logging
 import time
 import zipfile
+from collections import defaultdict
 from pathlib import Path
 from time import sleep
 from typing import Any, Collection, Dict, List, Tuple, TypeVar, Union
@@ -280,9 +281,7 @@ def _get_run_information(
         return Response(error=DatabricksAPIError(**run))
 
     try:
-        cluster_id, tasks = _get_cluster_id_and_tasks_from_run_tasks(
-            run["tasks"], exclude_tasks, project_id
-        )
+        cluster_id, tasks = _get_cluster_id_and_tasks_from_run_tasks(run, exclude_tasks, project_id)
     except Exception as e:
         return Response(error=DatabricksError(message=str(e)))
 
@@ -343,9 +342,7 @@ def get_cluster_report(
         return Response(error=DatabricksAPIError(**run))
 
     try:
-        cluster_id, tasks = _get_cluster_id_and_tasks_from_run_tasks(
-            run["tasks"], exclude_tasks, project_id
-        )
+        cluster_id, tasks = _get_cluster_id_and_tasks_from_run_tasks(run, exclude_tasks, project_id)
     except Exception as e:
         return Response(error=DatabricksError(message=str(e)))
 
@@ -1027,40 +1024,49 @@ def _get_job_cluster(tasks: List[dict], job_clusters: list) -> Response[dict]:
 
 
 def _get_cluster_id_and_tasks_from_run_tasks(
-    all_tasks: List[dict],
+    run: dict,
     exclude_tasks: Union[Collection[str], None] = None,
     project_id: str = None,
 ) -> Tuple[str, List[dict]]:
-    cluster_id_to_tasks = {}
-    for task in all_tasks:
+    job_clusters = {c["job_cluster_key"]: c["new_cluster"] for c in run.get("job_clusters")}
+    project_cluster_ids = defaultdict(list)
+    all_cluster_tasks = defaultdict(list)
+    for task in run["tasks"]:
         if not exclude_tasks or task["task_key"] not in exclude_tasks:
             cluster_id = task["cluster_instance"]["cluster_id"]
-            if cluster_id not in cluster_id_to_tasks:
-                cluster_id_to_tasks[cluster_id] = [task]
-            else:
-                cluster_id_to_tasks[cluster_id].append(task)
+            all_cluster_tasks[cluster_id].append(task)
 
-    num_ids = len(cluster_id_to_tasks)
-    if num_ids == 0:
-        raise Exception("No cluster found for tasks")
-    elif num_ids > 1:
-        raise Exception("More than 1 cluster found for tasks")
+            task_cluster = task.get("new_cluster")
+            if not task_cluster:
+                task_cluster = job_clusters.get(task.get("job_cluster_key"))
 
-    cluster_id, tasks = cluster_id_to_tasks.popitem()
+            if task_cluster:
+                cluster_project_id = task_cluster.get("custom_tags", {}).get("sync:project-id")
+                if cluster_project_id:
+                    project_cluster_ids[cluster_project_id].append(cluster_id)
+
+    project_cluster_tasks = None
     if project_id:
-        project_tasks = [
-            t
-            for t in tasks
-            if t.get("new_cluster", {}).get("custom_tags", {}).get("sync:project-id") == project_id
-        ]
-        if project_tasks:
-            tasks = project_tasks
+        cluster_ids = project_cluster_ids.get(project_id)
+        if cluster_ids:
+            project_cluster_tasks = {
+                cluster_id: tasks
+                for cluster_id, tasks in all_cluster_tasks
+                if cluster_id in cluster_ids
+            }
         else:
             logger.warning(
                 "No task clusters found matching the provided project-id - assuming all non-excluded tasks are relevant"
             )
 
-    return cluster_id, tasks
+    cluster_tasks = project_cluster_tasks or all_cluster_tasks
+    num_clusters = len(cluster_tasks)
+    if num_clusters == 0:
+        raise Exception("No cluster found for tasks")
+    elif num_clusters > 1:
+        raise Exception("More than 1 cluster found for tasks")
+
+    return cluster_tasks.popitem()
 
 
 def _get_run_spark_context_id(tasks: List[dict]) -> Response[str]:

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -19,6 +19,7 @@ from sync._databricks import (
     create_cluster,
     create_prediction_for_run,
     create_run,
+    create_submission_for_run,
     event_log_poll_duration_seconds,
     get_cluster,
     get_cluster_report,
@@ -57,6 +58,7 @@ __all__ = [
     "run_prediction",
     "run_and_record_job",
     "create_prediction_for_run",
+    "create_submission_for_run",
     "get_cluster_report",
     "monitor_cluster",
     "create_cluster",
@@ -180,7 +182,11 @@ def get_access_report(log_url: str = None) -> AccessReport:
 
 
 def _get_cluster_report(
-    cluster_id: str, plan_type: str, compute_type: str, allow_incomplete: bool
+    cluster_id: str,
+    cluster_tasks: List[dict],
+    plan_type: str,
+    compute_type: str,
+    allow_incomplete: bool,
 ) -> Response[AWSDatabricksClusterReport]:
     # Cluster `terminated_time` can be a few seconds after the start of the next task in which
     # this may be executing.
@@ -206,8 +212,9 @@ def _get_cluster_report(
             compute_type=compute_type,
             cluster=cluster,
             cluster_events=cluster_events,
-            instances=reservations.result,
             volumes=volumes.result,
+            tasks=cluster_tasks,
+            instances=reservations.result,
         )
     )
 

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from time import sleep
-from typing import Type, TypeVar
+from typing import List, Type, TypeVar
 from urllib.parse import urlparse
 
 import orjson
@@ -22,6 +22,7 @@ from sync._databricks import (
     create_cluster,
     create_prediction_for_run,
     create_run,
+    create_submission_for_run,
     event_log_poll_duration_seconds,
     get_cluster,
     get_cluster_report,
@@ -62,6 +63,7 @@ __all__ = [
     "create_cluster",
     "get_cluster",
     "create_prediction_for_run",
+    "create_submission_for_run",
     "get_cluster_report",
     "record_run",
     "get_prediction_job",
@@ -188,7 +190,11 @@ def get_access_report(log_url: str = None) -> AccessReport:
 
 
 def _get_cluster_report(
-    cluster_id: str, plan_type: str, compute_type: str, allow_incomplete: bool
+    cluster_id: str,
+    cluster_tasks: List[dict],
+    plan_type: str,
+    compute_type: str,
+    allow_incomplete: bool,
 ) -> Response[AzureDatabricksClusterReport]:
     # Cluster `terminated_time` can be a few seconds after the start of the next task in which
     # this may be executing.
@@ -212,6 +218,7 @@ def _get_cluster_report(
             compute_type=compute_type,
             cluster=cluster,
             cluster_events=cluster_events,
+            tasks=cluster_tasks,
             instances=instances.result,
         )
     )

--- a/sync/cli/awsdatabricks.py
+++ b/sync/cli/awsdatabricks.py
@@ -3,6 +3,7 @@ import click
 from sync.cli._databricks import (
     access_report,
     create_prediction,
+    create_submission,
     get_cluster_report,
     monitor_cluster,
     run_job,
@@ -22,5 +23,6 @@ aws_databricks.add_command(access_report)
 aws_databricks.add_command(run_prediction)
 aws_databricks.add_command(run_job)
 aws_databricks.add_command(create_prediction)
+aws_databricks.add_command(create_submission)
 aws_databricks.add_command(get_cluster_report)
 aws_databricks.add_command(monitor_cluster)

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -103,6 +103,23 @@ def create_project_prediction(project: Dict[str, str], run_id: str = None, regio
 
 
 @aws_emr.command
+@click.option(
+    "--project", callback=validate_project, help="The project ID for which to submit data."
+)
+@click.option("-r", "--run-id")
+@click.option("-r", "--region")
+def create_submission(run_id: str, project: dict, region: str = None):
+    """Create a submission for a job run"""
+    submission_response = awsemr.create_submission(project["id"], run_id, region)
+    submission = submission_response.result
+    if submission:
+        click.echo(f"Submission ID: {submission}")
+    else:
+        click.echo(f"Failed to submit data. {submission_response.error}", err=True)
+    return
+
+
+@aws_emr.command
 @click.argument("cluster-id")
 @click.option("-r", "--region")
 def get_cluster_report(cluster_id: str, region: str = None):

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -103,8 +103,8 @@ def create_project_prediction(project: Dict[str, str], run_id: str = None, regio
 
 
 @aws_emr.command
-@click.option(
-    "--project", callback=validate_project, help="The project ID for which to submit data."
+@click.argument(
+    "project", callback=validate_project, help="The project ID for which to submit data."
 )
 @click.option("-r", "--run-id")
 @click.option("-r", "--region")

--- a/sync/cli/azuredatabricks.py
+++ b/sync/cli/azuredatabricks.py
@@ -3,6 +3,7 @@ import click
 from sync.cli._databricks import (
     access_report,
     create_prediction,
+    create_submission,
     get_cluster_report,
     monitor_cluster,
     run_job,
@@ -22,5 +23,6 @@ azure_databricks.add_command(access_report)
 azure_databricks.add_command(run_prediction)
 azure_databricks.add_command(run_job)
 azure_databricks.add_command(create_prediction)
+azure_databricks.add_command(create_submission)
 azure_databricks.add_command(get_cluster_report)
 azure_databricks.add_command(monitor_cluster)

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -13,8 +13,7 @@ class SyncAuth(httpx.Auth):
     requires_response_body = True
 
     def __init__(self, api_url: str, api_key: APIKey):
-        # self.auth_url = f"{api_url}/v1/auth/token"
-        self.auth_url = "https://dev-api.synccomputing.com/v1/auth/token"
+        self.auth_url = f"{api_url}/v1/auth/token"
         self.api_key = api_key
         self._access_token = None
 

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -13,7 +13,8 @@ class SyncAuth(httpx.Auth):
     requires_response_body = True
 
     def __init__(self, api_url: str, api_key: APIKey):
-        self.auth_url = f"{api_url}/v1/auth/token"
+        # self.auth_url = f"{api_url}/v1/auth/token"
+        self.auth_url = "https://dev-api.synccomputing.com/v1/auth/token"
         self.api_key = api_key
         self._access_token = None
 
@@ -110,6 +111,14 @@ class SyncClient(RetryableHTTPClient):
 
     def delete_project(self, project_id: str) -> dict:
         return self._send(self._client.build_request("DELETE", f"/v1/projects/{project_id}"))
+
+    def create_project_submission(self, project_id: str, submission: dict) -> dict:
+        headers, content = encode_json(submission)
+        return self._send(
+            self._client.build_request(
+                "POST", f"/v1/projects/{project_id}/submissions", headers=headers, content=content
+            )
+        )
 
     def _send(self, request: httpx.Request) -> dict:
         response = self._send_request(request)

--- a/sync/models.py
+++ b/sync/models.py
@@ -78,6 +78,10 @@ class ProjectError(Error):
     code: str = Field("Project Error", const=True)
 
 
+class SubmissionError(Error):
+    code: str = Field("Submission Error", const=True)
+
+
 class EMRError(Error):
     code: str = Field("EMR Error", const=True)
 
@@ -101,6 +105,7 @@ class DatabricksClusterReport(BaseModel):
     compute_type: DatabricksComputeType
     cluster: dict
     cluster_events: dict
+    tasks: List[dict]
 
 
 class AWSDatabricksClusterReport(DatabricksClusterReport):

--- a/tests/api/test_predictions.py
+++ b/tests/api/test_predictions.py
@@ -3,10 +3,11 @@ import respx
 from httpx import Response
 
 from sync.api import predictions
+from sync.config import CONFIG
 from sync.models import Platform
 
 # auth route will only be called in the first test
-mock_router = respx.mock(base_url="https://*.synccomputing.com", assert_all_called=False)
+mock_router = respx.mock(base_url=CONFIG.api_url, assert_all_called=False)
 mock_router.post("/v1/auth/token").mock(
     return_value=Response(
         200,

--- a/tests/asyncapi/test_asyncpredictions.py
+++ b/tests/asyncapi/test_asyncpredictions.py
@@ -4,10 +4,11 @@ import respx
 from httpx import Response
 
 from sync.asyncapi import predictions
+from sync.config import CONFIG
 from sync.models import Platform
 
 # auth route will only be called in the first test
-mock_router = respx.mock(base_url="https://*.synccomputing.com", assert_all_called=False)
+mock_router = respx.mock(base_url=CONFIG.api_url, assert_all_called=False)
 mock_router.post("/v1/auth/token").mock(
     return_value=Response(
         200,

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -538,7 +538,13 @@ def test_create_prediction_for_failed_run(respx_mock):
 
     failure_response = {
         "state": {"result_state": "FAILED"},
-        "tasks": [{"task_key": "tpcds_2000GB_group_q76_q80", "state": {"result_state": "FAILED"}}],
+        "tasks": [
+            {
+                "task_key": "tpcds_2000GB_group_q76_q80",
+                "cluster_instance": {"cluster_id": 12345},
+                "state": {"result_state": "FAILED"},
+            }
+        ],
     }
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=failure_response)


### PR DESCRIPTION
This PR adds support for submitting data to the `/projects/{id}/submissions` endpoint for Databricks (AWS & Azure) as well as. Also adds support for passing the `tasks` that are related to a given Sync Project in the `/submissions` payload (there will be a corresponding backend PR for that).

After this PR is merged I'll quickly submit a 2nd one to add support for `/recommendations`