### PR TITLE
Sean/better ebs handling

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -277,6 +277,7 @@ def _get_run_information(
     exclude_tasks: Union[Collection[str], None] = None,
 ) -> Response[Tuple[DatabricksClusterReport, bytes]]:
     run = get_default_client().get_run(run_id)
+
     if "error_code" in run:
         return Response(error=DatabricksAPIError(**run))
 
@@ -1031,6 +1032,7 @@ def _get_cluster_id_and_tasks_from_run_tasks(
     job_clusters = {c["job_cluster_key"]: c["new_cluster"] for c in run.get("job_clusters", [])}
     project_cluster_ids = defaultdict(list)
     all_cluster_tasks = defaultdict(list)
+
     for task in run["tasks"]:
         if not exclude_tasks or task["task_key"] not in exclude_tasks:
             cluster_id = task["cluster_instance"]["cluster_id"]
@@ -1051,7 +1053,7 @@ def _get_cluster_id_and_tasks_from_run_tasks(
         if cluster_ids:
             project_cluster_tasks = {
                 cluster_id: tasks
-                for cluster_id, tasks in all_cluster_tasks
+                for cluster_id, tasks in all_cluster_tasks.items()
                 if cluster_id in cluster_ids
             }
         else:

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -283,6 +283,7 @@ def _get_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict]
     if not cluster_info:
         volumes_response = Response(error=DatabricksError(message=missing_message("ebs volumes")))
     else:
+        logger.warning(missing_message("ebs volumes"))
         volumes_response = Response(result={"Volumes": cluster_info.get("Volumes", [])})
 
     return reservations_response, volumes_response
@@ -320,8 +321,6 @@ def _monitor_cluster(
     cluster_log_destination, cluster_id: str, spark_context_id: int, polling_period: int
 ) -> None:
     
-    logging.basicConfig(level=logging.INFO) # Not the right place for this, I know
-
     (log_url, filesystem, bucket, base_prefix) = cluster_log_destination
     # If the event log destination is just a *bucket* without any sub-path, then we don't want to include
     #  a leading `/` in our Prefix (which will make it so that we never actually find the event log), so

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -277,7 +277,7 @@ def _get_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict]
             + "https://docs.synccomputing.com/sync-gradient/integrating-with-gradient/databricks-workflows"
         )
 
-    if not cluster_info or not cluster_info["Reservations"]:
+    if not cluster_info or not cluster_info.get("Reservations"):
         reservations_response = Response(
             error=DatabricksError(message=missing_message("instances"))
         )
@@ -287,7 +287,6 @@ def _get_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict]
     if not cluster_info:
         volumes_response = Response(error=DatabricksError(message=missing_message("ebs volumes")))
     else:
-        logger.warning(missing_message("ebs volumes"))
         volumes_response = Response(result={"Volumes": cluster_info.get("Volumes", [])})
 
     return reservations_response, volumes_response

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -319,6 +319,9 @@ def monitor_cluster(cluster_id: str, polling_period: int = 30) -> None:
 def _monitor_cluster(
     cluster_log_destination, cluster_id: str, spark_context_id: int, polling_period: int
 ) -> None:
+    
+    logging.basicConfig(level=logging.INFO) # Not the right place for this, I know
+
     (log_url, filesystem, bucket, base_prefix) = cluster_log_destination
     # If the event log destination is just a *bucket* without any sub-path, then we don't want to include
     #  a leading `/` in our Prefix (which will make it so that we never actually find the event log), so

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -256,12 +256,12 @@ def _get_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict]
     # If this cluster does not have the "Sync agent" configured, attempt a best-effort snapshot of the instances that
     #  are associated with this cluster
     if not cluster_info:
-        ec2 = boto.client("ec2", region_name=aws_region_name)
-
-        reservations = _get_ec2_instances(cluster_id, ec2)
-        volumes = _get_ebs_volumes_for_reservations(reservations, ec2)
 
         try:
+            ec2 = boto.client("ec2", region_name=aws_region_name)
+            reservations = _get_ec2_instances(cluster_id, ec2)
+            volumes = _get_ebs_volumes_for_reservations(reservations, ec2)
+
             cluster_info = {
                 "Reservations": reservations,
                 "Volumes": volumes,


### PR DESCRIPTION
Changed EBS fetching to filter by attached instance-ids rather than the `ClusterId` tag. Turns out databricks will repurpose EBS volumes, but WILL NOT update the tags when it does so. Harumph.

Also fixed an iteration bug on the tasks that would occasionally throw an error.