### PR TITLE
Increase timeout period for get cluster state

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1057,7 +1057,7 @@ def terminate_cluster(cluster_id: str) -> Response[dict]:
 
 
 def _wait_for_cluster_termination(
-    cluster_id: str, timeout_seconds=300, poll_seconds=10
+    cluster_id: str, timeout_seconds=600, poll_seconds=10
 ) -> Response[dict]:
     start_seconds = time.time()
     cluster = get_default_client().get_cluster(cluster_id)

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1059,6 +1059,7 @@ def terminate_cluster(cluster_id: str) -> Response[dict]:
 def _wait_for_cluster_termination(
     cluster_id: str, timeout_seconds=600, poll_seconds=10
 ) -> Response[dict]:
+    logging.info(f"Waiting for cluster {cluster_id} to terminate")
     start_seconds = time.time()
     cluster = get_default_client().get_cluster(cluster_id)
     while "error_code" not in cluster:


### PR DESCRIPTION
During gradient testing, it was noticed that there are cases where it takes longer than 300 seconds for a databricks cluster to spin down. This is incompatible with the default timeout period of 300 seconds and causes submission failures for successful job completions. The timeout is now increased to 600 seconds. 