### PR TITLE
Fix for bug in finding job clusters

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1385,7 +1385,7 @@ def _get_project_job_clusters(
     job_clusters = {
         c["job_cluster_key"]: c["new_cluster"] for c in job["settings"].get("job_clusters", [])
     }
-    all_project_clusters = defaultdict(list)
+    all_project_clusters = defaultdict(dict)
 
     for task in job["settings"]["tasks"]:
         if not exclude_tasks or task["task_key"] not in exclude_tasks:
@@ -1399,14 +1399,14 @@ def _get_project_job_clusters(
 
             if task_cluster:
                 cluster_project_id = task_cluster.get("custom_tags", {}).get("sync:project-id")
-                all_project_clusters[cluster_project_id].append((task_cluster_path, task_cluster))
+                all_project_clusters[cluster_project_id][task_cluster_path] = task_cluster
 
     filtered_project_clusters = {}
     for project_id, clusters in all_project_clusters.items():
         if len(clusters) > 1:
             logger.warning(f"More than 1 cluster found for project ID {project_id}")
         else:
-            filtered_project_clusters[project_id] = clusters[0]
+            filtered_project_clusters[project_id] = next(iter(clusters.items()))
 
     return filtered_project_clusters
 


### PR DESCRIPTION
Manually tested:
```
>>> from sync.clients import databricks
>>> client = databricks.get_default_client()
>>> job = client.get_job("1084595443498678")
>>> from sync import _databricks
>>> x =_databricks._get_project_job_clusters(job)
>>> type(x)
<class 'dict'>
>>> x["66c7dc8f-ff02-4a3f-a14d-dbcfc31e17e0"][0]
('job_clusters', 'gradientML_sf1_static_compute')
>>> x["66c7dc8f-ff02-4a3f-a14d-dbcfc31e17e0"][1]
...
```