### PR TITLE
[PROD-1295] Use project cluster_path

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.4.10"
+__version__ = "0.4.11"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1708,7 +1708,7 @@ def _dbfs_directory_has_all_rollover_logs(contents: dict, run_end_time_millis: f
     )
 
 
-def event_log_poll_duration_seconds():
+def _event_log_poll_duration_seconds():
     """Convenience function to aid testing"""
     return 15
 
@@ -1861,7 +1861,7 @@ def _get_eventlog(
     #   https://docs.databricks.com/clusters/configure.html#cluster-log-delivery-1
     # So we will poll this location for *up to* 5 minutes until we see all the eventlog files we are expecting
     # in the S3 bucket
-    poll_duration_seconds = event_log_poll_duration_seconds()
+    poll_duration_seconds = _event_log_poll_duration_seconds()
 
     if filesystem == "s3":
         return _get_eventlog_from_s3(

--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -53,6 +53,8 @@ def create_project(
     product_code: str,
     description: str = None,
     job_id: str = None,
+    cluster_path: str = None,
+    workspace_id: str = None,
     cluster_log_url: str = None,
     prediction_preference: Preference = Preference.ECONOMY,
     auto_apply_recs: bool = False,
@@ -69,6 +71,10 @@ def create_project(
     :type description: str, optional
     :param job_id: Databricks job ID, defaults to None
     :type job_id: str, optional
+    :param cluster_path: path to cluster definition in job object, defaults to None
+    :type cluster_path: str, optional
+    :param workspace_id: Databricks workspace ID, defaults to None
+    :type workspace_id: str, optional
     :param cluster_log_url: S3 or DBFS URL under which to store project configurations and logs, defaults to None
     :type cluster_log_url: str, optional
     :param prediction_preference: preferred prediction solution, defaults to `Preference.ECONOMY`
@@ -89,6 +95,8 @@ def create_project(
                 "product_code": product_code,
                 "description": description,
                 "job_id": job_id,
+                "cluster_path": cluster_path,
+                "workspace_id": workspace_id,
                 "cluster_log_url": cluster_log_url,
                 "prediction_preference": prediction_preference,
                 "auto_apply_recs": auto_apply_recs,
@@ -113,6 +121,8 @@ def get_project(project_id: str) -> Response[dict]:
 def update_project(
     project_id: str,
     description: str = None,
+    cluster_path: str = None,
+    workspace_id: str = None,
     cluster_log_url: str = None,
     app_id: str = None,
     prediction_preference: Preference = None,
@@ -125,6 +135,10 @@ def update_project(
     :type project_id: str
     :param description: description, defaults to None
     :type description: str, optional
+    :param cluster_path: path to cluster definition in job object, defaults to None
+    :type cluster_path: str, optional
+    :param workspace_id: Databricks workspace ID, defaults to None
+    :type workspace_id: str, optional
     :param cluster_log_url: location of project event logs and configurations, defaults to None
     :type cluster_log_url: str, optional
     :param app_id: external identifier, defaults to None
@@ -151,6 +165,10 @@ def update_project(
         project_update["auto_apply_recs"] = auto_apply_recs
     if prediction_params:
         project_update["prediction_params"] = prediction_params
+    if cluster_path:
+        project_update["cluster_path"] = cluster_path
+    if workspace_id:
+        project_update["workspace_id"] = workspace_id
 
     return Response(
         **get_default_client().update_project(

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -22,7 +22,6 @@ from sync._databricks import (
     create_prediction_for_run,
     create_run,
     create_submission_for_run,
-    event_log_poll_duration_seconds,
     get_cluster,
     get_cluster_report,
     get_prediction_cluster,
@@ -86,7 +85,6 @@ __all__ = [
     "wait_for_final_run_status",
     "wait_for_run_and_cluster",
     "terminate_cluster",
-    "event_log_poll_duration_seconds",
     "apply_prediction",
     "apply_project_recommendation",
 ]

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -26,7 +26,6 @@ from sync._databricks import (
     create_prediction_for_run,
     create_run,
     create_submission_for_run,
-    event_log_poll_duration_seconds,
     get_cluster,
     get_cluster_report,
     get_prediction_cluster,
@@ -90,7 +89,6 @@ __all__ = [
     "wait_for_final_run_status",
     "wait_for_run_and_cluster",
     "terminate_cluster",
-    "event_log_poll_duration_seconds",
     "apply_prediction",
     "apply_project_recommendation",
 ]

--- a/sync/cli/projects.py
+++ b/sync/cli/projects.py
@@ -55,6 +55,12 @@ def get(project: dict):
 @click.argument("product_code")
 @click.option("-d", "--description")
 @click.option("-j", "--job-id", help="Databricks job ID")
+@click.option(
+    "-c",
+    "--cluster-path",
+    help="Path to cluster definition in job object, e.g. 'job_clusters/Job_cluster'",
+)
+@click.option("-w", "--workspace-id", help="Databricks workspace ID")
 @click.option("-l", "--location", help="S3 URL under which to store event logs and configuration")
 @click.option(
     "-p",
@@ -77,6 +83,8 @@ def create(
     auto_apply_recs: bool,
     description: str = None,
     job_id: str = None,
+    cluster_path: str = None,
+    workspace_id: str = None,
     location: str = None,
     preference: Preference = None,
     app_id: str = None,
@@ -89,6 +97,8 @@ def create(
         product_code,
         description=description,
         job_id=job_id,
+        cluster_path=cluster_path,
+        workspace_id=workspace_id,
         cluster_log_url=location,
         prediction_preference=preference,
         auto_apply_recs=auto_apply_recs,
@@ -109,6 +119,12 @@ def create(
     "-i", "--app-id", help="External identifier often based on the project's target application"
 )
 @click.option(
+    "-c",
+    "--cluster-path",
+    help="Path to cluster definition in job object, e.g. 'job_clusters/Job_cluster'",
+)
+@click.option("-w", "--workspace-id", help="Databricks workspace ID")
+@click.option(
     "-p",
     "--preference",
     type=click.Choice(Preference),
@@ -120,6 +136,8 @@ def update(
     description: str = None,
     location: str = None,
     app_id: str = None,
+    cluster_path: str = None,
+    workspace_id: str = None,
     preference: Preference = None,
     auto_apply_recs: bool = None,
 ):
@@ -129,6 +147,8 @@ def update(
         description=description,
         cluster_log_url=location,
         app_id=app_id,
+        cluster_path=cluster_path,
+        workspace_id=workspace_id,
         prediction_preference=preference,
         auto_apply_recs=auto_apply_recs,
     )

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -948,13 +948,9 @@ def test_create_prediction_for_run_with_pending_task(respx_mock):
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
-@patch("sync.awsdatabricks.event_log_poll_duration_seconds")
+@patch("sync._databricks._event_log_poll_duration_seconds", Mock(return_value=0))
 @patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
-def test_create_prediction_for_run_event_log_upload_delay(
-    event_log_poll_duration_seconds, respx_mock
-):
-    event_log_poll_duration_seconds.return_value = 0
-
+def test_create_prediction_for_run_event_log_upload_delay(respx_mock):
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=MOCK_RUN)
     )

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -1,7 +1,7 @@
 import copy
 import io
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import boto3 as boto
@@ -13,6 +13,7 @@ from httpx import Response
 from sync.awsdatabricks import create_prediction_for_run
 from sync.config import DatabricksConf
 from sync.models import DatabricksAPIError, DatabricksError
+from sync.models import Response as SyncResponse
 
 MOCK_RUN = {
     "job_id": 12345678910,
@@ -524,6 +525,7 @@ MOCK_DBX_CONF = DatabricksConf(
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_failed_run(respx_mock):
     failure_response = {"error_code": "FAILED", "message": "This run failed"}
 
@@ -558,12 +560,18 @@ def test_create_prediction_for_failed_run(respx_mock):
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_bad_cluster_data(respx_mock):
     # Test too many clusters found
     run_with_multiple_clusters = copy.deepcopy(MOCK_RUN)
+
     run_with_multiple_clusters["tasks"][0]["cluster_instance"][
         "cluster_id"
     ] = "different_cluster_id"
+    del run_with_multiple_clusters["tasks"][0]["job_cluster_key"]
+    run_with_multiple_clusters["tasks"][0]["new_cluster"] = run_with_multiple_clusters[
+        "job_clusters"
+    ][0]["new_cluster"]
 
     run_with_multiple_clusters["tasks"] = [
         MOCK_RUN["tasks"][0],
@@ -592,6 +600,7 @@ def test_create_prediction_for_run_bad_cluster_data(respx_mock):
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_no_instances_found(respx_mock):
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=MOCK_RUN)
@@ -631,6 +640,7 @@ def test_create_prediction_for_run_no_instances_found(respx_mock):
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_unauthorized_ec2(respx_mock):
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=MOCK_RUN)
@@ -679,6 +689,7 @@ MOCK_PREDICTION_CREATION_RESPONSE = {
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_success(respx_mock):
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=MOCK_RUN)
@@ -760,6 +771,7 @@ def test_create_prediction_for_run_success(respx_mock):
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock):
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=MOCK_RUN)
@@ -858,6 +870,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
 
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_with_pending_task(respx_mock):
     respx_mock.get("https://*.cloud.databricks.com/api/2.1/jobs/runs/get?run_id=75778").mock(
         return_value=Response(200, json=MOCK_RUN_WITH_SYNC_TASK)
@@ -941,6 +954,7 @@ def test_create_prediction_for_run_with_pending_task(respx_mock):
 @patch("sync.awsdatabricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.clients.databricks.DB_CONFIG", new=MOCK_DBX_CONF)
 @patch("sync.awsdatabricks.event_log_poll_duration_seconds")
+@patch("sync._databricks.get_project", Mock(return_value=SyncResponse(result={})))
 def test_create_prediction_for_run_event_log_upload_delay(
     event_log_poll_duration_seconds, respx_mock
 ):

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -564,14 +564,9 @@ def test_create_prediction_for_failed_run(respx_mock):
 def test_create_prediction_for_run_bad_cluster_data(respx_mock):
     # Test too many clusters found
     run_with_multiple_clusters = copy.deepcopy(MOCK_RUN)
-
     run_with_multiple_clusters["tasks"][0]["cluster_instance"][
         "cluster_id"
     ] = "different_cluster_id"
-    del run_with_multiple_clusters["tasks"][0]["job_cluster_key"]
-    run_with_multiple_clusters["tasks"][0]["new_cluster"] = run_with_multiple_clusters[
-        "job_clusters"
-    ][0]["new_cluster"]
 
     run_with_multiple_clusters["tasks"] = [
         MOCK_RUN["tasks"][0],


### PR DESCRIPTION
Adds `cluster_path` to projects to support multi-cluster Databricks jobs. Also adds `workspace_id` to projects to help locate integration secrets for automating job/cluster onboarding. Both are optional.

With `cluster_path` we can better locate the cluster for the project which removes blockers around multi-cluster Databricks jobs.

https://synccomputing.atlassian.net/browse/PROD-1295