### PR TITLE
[CB-2] Fix bug in finding cluster in run

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.4.12"
+__version__ = "0.4.13"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1611,8 +1611,8 @@ def _get_cluster_tasks(
     job_clusters = {c["job_cluster_key"]: c["new_cluster"] for c in run.get("job_clusters", [])}
 
     cluster_id_tasks = defaultdict(list)
-    cluster_path_ids = defaultdict(list)
-    cluster_project_paths = defaultdict(list)
+    cluster_path_ids = defaultdict(set)
+    cluster_project_paths = defaultdict(set)
 
     for task in run["tasks"]:
         if "cluster_instance" in task and (
@@ -1630,15 +1630,15 @@ def _get_cluster_tasks(
             if task_cluster:
                 cluster_project_id = task_cluster.get("custom_tags", {}).get("sync:project-id")
                 cluster_id_tasks[cluster_id].append(task)
-                cluster_path_ids[cluster_path].append(cluster_id)
-                cluster_project_paths[cluster_project_id].append(cluster_path)
+                cluster_path_ids[cluster_path].add(cluster_id)
+                cluster_project_paths[cluster_project_id].add(cluster_path)
 
     result_cluster_project_tasks = {}
     for project_id, cluster_paths in cluster_project_paths.items():
         cluster_path_tasks = {}
         for cluster_path in cluster_paths:
             if len(cluster_path_ids[cluster_path]) == 1:
-                cluster_id = cluster_path_ids[cluster_path][0]
+                cluster_id = cluster_path_ids[cluster_path].pop()
                 cluster_path_tasks[cluster_path] = (cluster_id, cluster_id_tasks[cluster_id])
             else:
                 # Maybe this will happen if the same job cluster is used by 2 non adjacent tasks


### PR DESCRIPTION
https://synccomputing.atlassian.net/browse/CB-2
Looks good with manual testing:
```
>>> from sync import awsdatabricks
>>> import logging
>>> logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s [%(name)s] %(message)s")
>>> r = awsdatabricks.create_submission_for_run(475643548716943, "Standard", "Jobs Compute", "f88a5e38-f953-48cf-b0f0-44546b10aff3")
2023-11-17 12:02:48,293 INFO [root] Waiting for cluster 1117-142827-rmf0tm5u to terminate
>>> r
Response(result='517f82c6-08a7-4390-8827-b5110d0901cd', error=None)
```