### PR TITLE
orjson replacement with json package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "boto3~=1.26.0",
   "pydantic~=1.10.0",
   "httpx~=0.23.0",
-  "orjson~=3.8.0",
   "click~=8.1.0",
   "tenacity==8.2.2",
   "azure-identity==1.13.0",

--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from time import sleep
 from typing import List, Tuple
@@ -5,7 +6,6 @@ from urllib.parse import urlparse
 
 import boto3 as boto
 import botocore
-import json
 from botocore.exceptions import ClientError
 
 import sync._databricks
@@ -409,12 +409,15 @@ def _monitor_cluster(
             all_timelines = retired_timelines + list(active_timelines_by_id.values())
 
             write_file(
-                json.dumps(
-                    {
-                        "instances": list(all_inst_by_id.values()),
-                        "instance_timelines": all_timelines,
-                        "volumes": list(recorded_volumes_by_id.values()),
-                    }
+                bytes(
+                    json.dumps(
+                        {
+                            "instances": list(all_inst_by_id.values()),
+                            "instance_timelines": all_timelines,
+                            "volumes": list(recorded_volumes_by_id.values()),
+                        }
+                    ),
+                    "utf-8",
                 )
             )
         except Exception as e:

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 import boto3 as boto
 import botocore
-import orjson
+import json
 from botocore.exceptions import ClientError
 
 import sync._databricks
@@ -273,7 +273,7 @@ def _load_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict
             cluster_info_file_response = _get_cluster_instances_from_dbfs(cluster_info_file_key)
 
         cluster_info = (
-            orjson.loads(cluster_info_file_response) if cluster_info_file_response else None
+            json.loads(cluster_info_file_response) if cluster_info_file_response else None
         )
 
     # If this cluster does not have the "Sync agent" configured, attempt a best-effort snapshot of the instances that
@@ -409,7 +409,7 @@ def _monitor_cluster(
             all_timelines = retired_timelines + list(active_timelines_by_id.values())
 
             write_file(
-                orjson.dumps(
+                json.dumps(
                     {
                         "instances": list(all_inst_by_id.values()),
                         "instance_timelines": all_timelines,

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -56,6 +56,7 @@ from sync.models import (
     Response,
 )
 from sync.utils.dbfs import format_dbfs_filepath, write_dbfs_file
+from sync.utils.json import DefaultDateTimeEncoder
 
 __all__ = [
     "get_access_report",
@@ -415,7 +416,8 @@ def _monitor_cluster(
                             "instances": list(all_inst_by_id.values()),
                             "instance_timelines": all_timelines,
                             "volumes": list(recorded_volumes_by_id.values()),
-                        }
+                        },
+                        cls=DefaultDateTimeEncoder,
                     ),
                     "utf-8",
                 )

--- a/sync/awsemr.py
+++ b/sync/awsemr.py
@@ -28,7 +28,7 @@ from sync.models import (
     ProjectError,
     Response,
 )
-from syncsparkpy.sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderDropMicroseconds
 
 logger = logging.getLogger(__name__)
 

--- a/sync/awsemr.py
+++ b/sync/awsemr.py
@@ -4,6 +4,7 @@ Utilities for interacting with EMR
 
 import datetime
 import io
+import json
 import logging
 import re
 from copy import deepcopy
@@ -12,7 +13,6 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import boto3 as boto
-import json
 from dateutil.parser import parse as dateparse
 
 from sync import TIME_FORMAT
@@ -753,9 +753,7 @@ def _upload_object(obj: dict, s3_url: str) -> Response[str]:
     try:
         s3 = boto.client("s3")
         s3.upload_fileobj(
-            io.BytesIO(
-                bytes(json.dumps(obj, cls=DateTimeEncoderDropMicroseconds), 'utf-8')
-            ),
+            io.BytesIO(bytes(json.dumps(obj, cls=DateTimeEncoderDropMicroseconds), "utf-8")),
             parsed_url.netloc,
             obj_key,
         )

--- a/sync/awsemr.py
+++ b/sync/awsemr.py
@@ -28,7 +28,7 @@ from sync.models import (
     ProjectError,
     Response,
 )
-from sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 logger = logging.getLogger(__name__)
 
@@ -753,7 +753,9 @@ def _upload_object(obj: dict, s3_url: str) -> Response[str]:
     try:
         s3 = boto.client("s3")
         s3.upload_fileobj(
-            io.BytesIO(bytes(json.dumps(obj, cls=DateTimeEncoderDropMicroseconds), "utf-8")),
+            io.BytesIO(
+                bytes(json.dumps(obj, cls=DateTimeEncoderNaiveUTCDropMicroseconds), "utf-8")
+            ),
             parsed_url.netloc,
             obj_key,
         )

--- a/sync/awsemr.py
+++ b/sync/awsemr.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import boto3 as boto
-import orjson
+import json
 from dateutil.parser import parse as dateparse
 
 from sync import TIME_FORMAT
@@ -28,6 +28,7 @@ from sync.models import (
     ProjectError,
     Response,
 )
+from syncsparkpy.sync.utils.json import DateTimeEncoderDropMicroseconds
 
 logger = logging.getLogger(__name__)
 
@@ -364,7 +365,7 @@ def get_project_cluster_report(  # noqa: C901
                         s3.download_fileobj(parsed_project_url.netloc, config_key, config)
                         return Response(
                             result=(
-                                orjson.loads(config.getvalue().decode()),
+                                json.loads(config.getvalue().decode()),
                                 f"s3://{parsed_project_url.netloc}/{log_key}",
                             )
                         )
@@ -753,10 +754,7 @@ def _upload_object(obj: dict, s3_url: str) -> Response[str]:
         s3 = boto.client("s3")
         s3.upload_fileobj(
             io.BytesIO(
-                orjson.dumps(
-                    obj,
-                    option=orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS | orjson.OPT_NAIVE_UTC,
-                )
+                bytes(json.dumps(obj, cls=DateTimeEncoderDropMicroseconds), 'utf-8')
             ),
             parsed_url.netloc,
             obj_key,

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -59,6 +59,7 @@ from sync.models import (
     Response,
 )
 from sync.utils.dbfs import format_dbfs_filepath, write_dbfs_file
+from sync.utils.json import DefaultDateTimeEncoder
 
 __all__ = [
     "get_access_report",
@@ -374,7 +375,8 @@ def _monitor_cluster(
                         {
                             "instances": list(all_vms_by_id.values()),
                             "timelines": all_timelines,
-                        }
+                        },
+                        cls=DefaultDateTimeEncoder,
                     ),
                     "utf-8",
                 )

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import List, Dict, Type, TypeVar, Optional
 from urllib.parse import urlparse
 
-import orjson
+import json
 from azure.common.credentials import get_cli_profile
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import DefaultAzureCredential
@@ -266,7 +266,7 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
             )
 
         cluster_instances = (
-            orjson.loads(cluster_instances_file_response)
+            json.loads(cluster_instances_file_response)
             if cluster_instances_file_response
             else None
         )
@@ -371,12 +371,12 @@ def _monitor_cluster(
             all_timelines = retired_timelines + list(active_timelines_by_id.values())
 
             write_file(
-                orjson.dumps(
+                bytes(json.dumps(
                     {
                         "instances": list(all_vms_by_id.values()),
                         "timelines": all_timelines,
                     }
-                )
+                ), 'utf-8')
             )
 
         except Exception as e:

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -1,11 +1,11 @@
+import json
 import logging
 import os
 import sys
 from time import sleep
-from typing import List, Dict, Type, TypeVar, Optional
+from typing import Dict, List, Optional, Type, TypeVar
 from urllib.parse import urlparse
 
-import json
 from azure.common.credentials import get_cli_profile
 from azure.core.exceptions import ClientAuthenticationError
 from azure.identity import DefaultAzureCredential
@@ -266,9 +266,7 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
             )
 
         cluster_instances = (
-            json.loads(cluster_instances_file_response)
-            if cluster_instances_file_response
-            else None
+            json.loads(cluster_instances_file_response) if cluster_instances_file_response else None
         )
 
     # If this cluster does not have the "Sync agent" configured, attempt a best-effort snapshot of the instances that
@@ -371,12 +369,15 @@ def _monitor_cluster(
             all_timelines = retired_timelines + list(active_timelines_by_id.values())
 
             write_file(
-                bytes(json.dumps(
-                    {
-                        "instances": list(all_vms_by_id.values()),
-                        "timelines": all_timelines,
-                    }
-                ), 'utf-8')
+                bytes(
+                    json.dumps(
+                        {
+                            "instances": list(all_vms_by_id.values()),
+                            "timelines": all_timelines,
+                        }
+                    ),
+                    "utf-8",
+                )
             )
 
         except Exception as e:

--- a/sync/cli/_databricks.py
+++ b/sync/cli/_databricks.py
@@ -1,7 +1,7 @@
+import json
 from typing import Tuple
 
 import click
-import json
 
 from sync.api.projects import (
     create_project_recommendation,
@@ -204,7 +204,9 @@ def get_recommendation(project: dict, recommendation_id: str):
         else:
             click.echo(
                 json.dumps(
-                    recommendation, indent=2, cls=DateTimeEncoder,
+                    recommendation,
+                    indent=2,
+                    cls=DateTimeEncoder,
                 )
             )
     else:
@@ -224,7 +226,9 @@ def get_submission(project: dict, submission_id: str):
         else:
             click.echo(
                 json.dumps(
-                    submission, indent=2, cls=DateTimeEncoder,
+                    submission,
+                    indent=2,
+                    cls=DateTimeEncoder,
                 )
             )
     else:
@@ -277,7 +281,9 @@ def get_cluster_report(
     if config:
         click.echo(
             json.dumps(
-                config.dict(exclude_none=True), indent=2, cls=DateTimeEncoder,
+                config.dict(exclude_none=True),
+                indent=2,
+                cls=DateTimeEncoder,
             )
         )
     else:

--- a/sync/cli/_databricks.py
+++ b/sync/cli/_databricks.py
@@ -11,7 +11,7 @@ from sync.api.projects import (
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import DatabricksComputeType, DatabricksPlanType, Platform, Preference
-from sync.utils.json import DateTimeEncoder
+from sync.utils.json import DateTimeEncoderNaiveUTC
 
 pass_platform = click.make_pass_decorator(Platform)
 
@@ -206,7 +206,7 @@ def get_recommendation(project: dict, recommendation_id: str):
                 json.dumps(
                     recommendation,
                     indent=2,
-                    cls=DateTimeEncoder,
+                    cls=DateTimeEncoderNaiveUTC,
                 )
             )
     else:
@@ -228,7 +228,7 @@ def get_submission(project: dict, submission_id: str):
                 json.dumps(
                     submission,
                     indent=2,
-                    cls=DateTimeEncoder,
+                    cls=DateTimeEncoderNaiveUTC,
                 )
             )
     else:
@@ -283,7 +283,7 @@ def get_cluster_report(
             json.dumps(
                 config.dict(exclude_none=True),
                 indent=2,
-                cls=DateTimeEncoder,
+                cls=DateTimeEncoderNaiveUTC,
             )
         )
     else:

--- a/sync/cli/_databricks.py
+++ b/sync/cli/_databricks.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 import click
-import orjson
+import json
 
 from sync.api.projects import (
     create_project_recommendation,
@@ -11,6 +11,7 @@ from sync.api.projects import (
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import DatabricksComputeType, DatabricksPlanType, Platform, Preference
+from sync.utils.json import DateTimeEncoder
 
 pass_platform = click.make_pass_decorator(Platform)
 
@@ -202,9 +203,8 @@ def get_recommendation(project: dict, recommendation_id: str):
             click.echo("Recommendation generation failed.", err=True)
         else:
             click.echo(
-                orjson.dumps(
-                    recommendation,
-                    option=orjson.OPT_INDENT_2 | orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z,
+                json.dumps(
+                    recommendation, indent=2, cls=DateTimeEncoder,
                 )
             )
     else:
@@ -223,9 +223,8 @@ def get_submission(project: dict, submission_id: str):
             click.echo("Submission generation failed.", err=True)
         else:
             click.echo(
-                orjson.dumps(
-                    submission,
-                    option=orjson.OPT_INDENT_2 | orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z,
+                json.dumps(
+                    submission, indent=2, cls=DateTimeEncoder,
                 )
             )
     else:
@@ -277,9 +276,8 @@ def get_cluster_report(
     config = config_response.result
     if config:
         click.echo(
-            orjson.dumps(
-                config.dict(exclude_none=True),
-                option=orjson.OPT_INDENT_2 | orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z,
+            json.dumps(
+                config.dict(exclude_none=True), indent=2, cls=DateTimeEncoder,
             )
         )
     else:

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -1,14 +1,15 @@
+import json
 from io import TextIOWrapper
 from typing import Dict
 
 import click
-import orjson
 
 from sync import awsemr
 from sync.api.predictions import get_prediction
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Platform, Preference
+from sync.utils.json import DateTimeEncoder
 
 
 @click.group
@@ -34,7 +35,7 @@ def run_job_flow(job_flow: TextIOWrapper, project: dict = None, region: str = No
     """Run a job flow
 
     JOB_FLOW is a file containing the RunJobFlow request object"""
-    job_flow_obj = orjson.loads(job_flow.read())
+    job_flow_obj = json.loads(job_flow.read())
 
     run_response = awsemr.run_and_record_job_flow(
         job_flow_obj, project["id"] if project else None, region
@@ -125,11 +126,7 @@ def get_cluster_report(cluster_id: str, region: str = None):
     config_response = awsemr.get_cluster_report(cluster_id, region)
     config = config_response.result
     if config:
-        click.echo(
-            orjson.dumps(
-                config, option=orjson.OPT_INDENT_2 | orjson.OPT_NAIVE_UTC | orjson.OPT_UTC_Z
-            )
-        )
+        click.echo(json.dumps(config, indent=2, cls=DateTimeEncoder))
     else:
         click.echo(f"Failed to create prediction. {config_response.error}", err=True)
 

--- a/sync/cli/awsemr.py
+++ b/sync/cli/awsemr.py
@@ -9,7 +9,7 @@ from sync.api.predictions import get_prediction
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Platform, Preference
-from sync.utils.json import DateTimeEncoder
+from sync.utils.json import DateTimeEncoderNaiveUTC
 
 
 @click.group
@@ -126,7 +126,7 @@ def get_cluster_report(cluster_id: str, region: str = None):
     config_response = awsemr.get_cluster_report(cluster_id, region)
     config = config_response.result
     if config:
-        click.echo(json.dumps(config, indent=2, cls=DateTimeEncoder))
+        click.echo(json.dumps(config, indent=2, cls=DateTimeEncoderNaiveUTC))
     else:
         click.echo(f"Failed to create prediction. {config_response.error}", err=True)
 

--- a/sync/cli/predictions.py
+++ b/sync/cli/predictions.py
@@ -1,10 +1,10 @@
 import io
+import json
 from pathlib import Path
 from urllib.parse import urlparse
 
 import boto3 as boto
 import click
-import json
 
 from sync.api.predictions import (
     create_prediction,
@@ -83,11 +83,7 @@ def generate(
         prediction_response = wait_for_prediction(prediction_id, preference.value)
         prediction = prediction_response.result
         if prediction:
-            click.echo(
-                json.dumps(
-                    prediction, indent=2, cls = DateTimeEncoderDropMicroseconds
-                )
-            )
+            click.echo(json.dumps(prediction, indent=2, cls=DateTimeEncoderDropMicroseconds))
         else:
             click.echo(str(response.error), err=True)
     else:
@@ -158,11 +154,7 @@ def status(prediction_id: str):
 def get(prediction_id: str, preference: Preference):
     """Retrieve a prediction"""
     response = get_prediction(prediction_id, preference.value)
-    click.echo(
-        json.dumps(
-            response.result, indent=2, cls=DateTimeEncoderDropMicroseconds
-        )
-    )
+    click.echo(json.dumps(response.result, indent=2, cls=DateTimeEncoderDropMicroseconds))
 
 
 @predictions.command

--- a/sync/cli/predictions.py
+++ b/sync/cli/predictions.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import boto3 as boto
 import click
-import orjson
+import json
 
 from sync.api.predictions import (
     create_prediction,
@@ -17,6 +17,7 @@ from sync.api.predictions import (
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Platform, Preference
+from sync.utils.json import DateTimeEncoderDropMicroseconds
 
 
 @click.group
@@ -48,12 +49,12 @@ def generate(
     parsed_report_arg = urlparse(report)
     if parsed_report_arg.scheme == "":
         with open(report) as report_fobj:
-            report = orjson.loads(report_fobj.read())
+            report = json.loads(report_fobj.read())
     elif parsed_report_arg.scheme == "s3":
         s3 = boto.client("s3")
         report_io = io.BytesIO()
         s3.download_fileobj(parsed_report_arg.netloc, parsed_report_arg.path.lstrip("/"), report_io)
-        report = orjson.loads(report_io.getvalue())
+        report = json.loads(report_io.getvalue())
     else:
         ctx.fail("Unsupported report argument")
 
@@ -83,12 +84,8 @@ def generate(
         prediction = prediction_response.result
         if prediction:
             click.echo(
-                orjson.dumps(
-                    prediction,
-                    option=orjson.OPT_INDENT_2
-                    | orjson.OPT_UTC_Z
-                    | orjson.OPT_NAIVE_UTC
-                    | orjson.OPT_OMIT_MICROSECONDS,
+                json.dumps(
+                    prediction, indent=2, cls = DateTimeEncoderDropMicroseconds
                 )
             )
         else:
@@ -108,12 +105,12 @@ def create(ctx: click.Context, platform: Platform, event_log: str, report: str, 
     parsed_report_arg = urlparse(report)
     if parsed_report_arg.scheme == "":
         with open(report) as report_fobj:
-            report = orjson.loads(report_fobj.read())
+            report = json.loads(report_fobj.read())
     elif parsed_report_arg.scheme == "s3":
         s3 = boto.client("s3")
         report_io = io.BytesIO()
         s3.download_fileobj(parsed_report_arg.netloc, parsed_report_arg.path.lstrip("/"), report_io)
-        report = orjson.loads(report_io.getvalue())
+        report = json.loads(report_io.getvalue())
     else:
         ctx.fail("Unsupported report argument")
 
@@ -162,12 +159,8 @@ def get(prediction_id: str, preference: Preference):
     """Retrieve a prediction"""
     response = get_prediction(prediction_id, preference.value)
     click.echo(
-        orjson.dumps(
-            response.result,
-            option=orjson.OPT_INDENT_2
-            | orjson.OPT_UTC_Z
-            | orjson.OPT_NAIVE_UTC
-            | orjson.OPT_OMIT_MICROSECONDS,
+        json.dumps(
+            response.result, indent=2, cls=DateTimeEncoderDropMicroseconds
         )
     )
 

--- a/sync/cli/predictions.py
+++ b/sync/cli/predictions.py
@@ -17,7 +17,7 @@ from sync.api.predictions import (
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Platform, Preference
-from sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 
 @click.group
@@ -83,7 +83,9 @@ def generate(
         prediction_response = wait_for_prediction(prediction_id, preference.value)
         prediction = prediction_response.result
         if prediction:
-            click.echo(json.dumps(prediction, indent=2, cls=DateTimeEncoderDropMicroseconds))
+            click.echo(
+                json.dumps(prediction, indent=2, cls=DateTimeEncoderNaiveUTCDropMicroseconds)
+            )
         else:
             click.echo(str(response.error), err=True)
     else:
@@ -154,7 +156,7 @@ def status(prediction_id: str):
 def get(prediction_id: str, preference: Preference):
     """Retrieve a prediction"""
     response = get_prediction(prediction_id, preference.value)
-    click.echo(json.dumps(response.result, indent=2, cls=DateTimeEncoderDropMicroseconds))
+    click.echo(json.dumps(response.result, indent=2, cls=DateTimeEncoderNaiveUTCDropMicroseconds))
 
 
 @predictions.command

--- a/sync/cli/projects.py
+++ b/sync/cli/projects.py
@@ -1,5 +1,6 @@
-import click
 import json
+
+import click
 
 from sync.api.projects import (
     create_project,
@@ -13,6 +14,7 @@ from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Preference
 from sync.utils.json import DateTimeEncoderDropMicroseconds
+
 
 @click.group
 def projects():
@@ -40,11 +42,7 @@ def get(project: dict):
     response = get_project(project["id"])
     project = response.result
     if project:
-        click.echo(
-            json.dumps(
-                project, indent=2, cls = DateTimeEncoderDropMicroseconds
-            )
-        )
+        click.echo(json.dumps(project, indent=2, cls=DateTimeEncoderDropMicroseconds))
     else:
         click.echo(str(response.error), err=True)
 
@@ -182,10 +180,6 @@ def get_latest_prediction(project: dict, preference: Preference):
     prediction_response = get_prediction(project["id"], preference)
     prediction = prediction_response.result
     if prediction:
-        click.echo(
-            json.dumps(
-                prediction, indent=2, cls=DateTimeEncoderDropMicroseconds
-            )
-        )
+        click.echo(json.dumps(prediction, indent=2, cls=DateTimeEncoderDropMicroseconds))
     else:
         click.echo(str(prediction_response.error), err=True)

--- a/sync/cli/projects.py
+++ b/sync/cli/projects.py
@@ -13,7 +13,7 @@ from sync.api.projects import (
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Preference
-from sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 
 @click.group
@@ -42,7 +42,7 @@ def get(project: dict):
     response = get_project(project["id"])
     project = response.result
     if project:
-        click.echo(json.dumps(project, indent=2, cls=DateTimeEncoderDropMicroseconds))
+        click.echo(json.dumps(project, indent=2, cls=DateTimeEncoderNaiveUTCDropMicroseconds))
     else:
         click.echo(str(response.error), err=True)
 
@@ -180,6 +180,6 @@ def get_latest_prediction(project: dict, preference: Preference):
     prediction_response = get_prediction(project["id"], preference)
     prediction = prediction_response.result
     if prediction:
-        click.echo(json.dumps(prediction, indent=2, cls=DateTimeEncoderDropMicroseconds))
+        click.echo(json.dumps(prediction, indent=2, cls=DateTimeEncoderNaiveUTCDropMicroseconds))
     else:
         click.echo(str(prediction_response.error), err=True)

--- a/sync/cli/projects.py
+++ b/sync/cli/projects.py
@@ -1,5 +1,5 @@
 import click
-import orjson
+import json
 
 from sync.api.projects import (
     create_project,
@@ -12,7 +12,7 @@ from sync.api.projects import (
 from sync.cli.util import validate_project
 from sync.config import CONFIG
 from sync.models import Preference
-
+from sync.utils.json import DateTimeEncoderDropMicroseconds
 
 @click.group
 def projects():
@@ -41,9 +41,8 @@ def get(project: dict):
     project = response.result
     if project:
         click.echo(
-            orjson.dumps(
-                project,
-                option=orjson.OPT_INDENT_2 | orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS,
+            json.dumps(
+                project, indent=2, cls = DateTimeEncoderDropMicroseconds
             )
         )
     else:
@@ -184,12 +183,8 @@ def get_latest_prediction(project: dict, preference: Preference):
     prediction = prediction_response.result
     if prediction:
         click.echo(
-            orjson.dumps(
-                prediction,
-                option=orjson.OPT_INDENT_2
-                | orjson.OPT_UTC_Z
-                | orjson.OPT_NAIVE_UTC
-                | orjson.OPT_OMIT_MICROSECONDS,
+            json.dumps(
+                prediction, indent=2, cls=DateTimeEncoderDropMicroseconds
             )
         )
     else:

--- a/sync/cli/workspaces.py
+++ b/sync/cli/workspaces.py
@@ -6,7 +6,7 @@ from sync.api import workspace
 from sync.cli.util import OPTIONAL_DEFAULT, validate_project
 from sync.config import API_KEY, DB_CONFIG
 from sync.models import DatabricksPlanType
-from sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 
 @click.group
@@ -77,7 +77,7 @@ def create_workspace_config(
     )
     config = response.result
     if config:
-        click.echo(json.dumps(config, indent=2, cls=DateTimeEncoderDropMicroseconds))
+        click.echo(json.dumps(config, indent=2, cls=DateTimeEncoderNaiveUTCDropMicroseconds))
     else:
         click.echo(str(response.error), err=True)
 
@@ -92,7 +92,7 @@ def get_workspace_config(workspace_id: str):
             json.dumps(
                 config,
                 indent=2,
-                cls=DateTimeEncoderDropMicroseconds,
+                cls=DateTimeEncoderNaiveUTCDropMicroseconds,
             )
         )
     else:
@@ -174,7 +174,7 @@ def update_workspace_config(
                 json.dumps(
                     config,
                     indent=2,
-                    cls=DateTimeEncoderDropMicroseconds,
+                    cls=DateTimeEncoderNaiveUTCDropMicroseconds,
                 )
             )
         else:
@@ -207,7 +207,7 @@ def reset_webhook_creds(workspace_id: str):
             json.dumps(
                 result,
                 indent=2,
-                cls=DateTimeEncoderDropMicroseconds,
+                cls=DateTimeEncoderNaiveUTCDropMicroseconds,
             )
         )
     else:

--- a/sync/cli/workspaces.py
+++ b/sync/cli/workspaces.py
@@ -1,5 +1,6 @@
-import click
 import json
+
+import click
 
 from sync.api import workspace
 from sync.cli.util import OPTIONAL_DEFAULT, validate_project
@@ -76,11 +77,7 @@ def create_workspace_config(
     )
     config = response.result
     if config:
-        click.echo(
-            json.dumps(
-                config, indent=2, cls=DateTimeEncoderDropMicroseconds
-            )
-        )
+        click.echo(json.dumps(config, indent=2, cls=DateTimeEncoderDropMicroseconds))
     else:
         click.echo(str(response.error), err=True)
 
@@ -93,7 +90,9 @@ def get_workspace_config(workspace_id: str):
     if config:
         click.echo(
             json.dumps(
-                config, indent=2, cls= DateTimeEncoderDropMicroseconds,
+                config,
+                indent=2,
+                cls=DateTimeEncoderDropMicroseconds,
             )
         )
     else:
@@ -173,7 +172,9 @@ def update_workspace_config(
         if config:
             click.echo(
                 json.dumps(
-                    config, indent=2, cls=DateTimeEncoderDropMicroseconds,
+                    config,
+                    indent=2,
+                    cls=DateTimeEncoderDropMicroseconds,
                 )
             )
         else:
@@ -204,7 +205,9 @@ def reset_webhook_creds(workspace_id: str):
     if result:
         click.echo(
             json.dumps(
-                result, indent=2, cls=DateTimeEncoderDropMicroseconds,
+                result,
+                indent=2,
+                cls=DateTimeEncoderDropMicroseconds,
             )
         )
     else:

--- a/sync/cli/workspaces.py
+++ b/sync/cli/workspaces.py
@@ -1,10 +1,11 @@
 import click
-import orjson
+import json
 
 from sync.api import workspace
 from sync.cli.util import OPTIONAL_DEFAULT, validate_project
 from sync.config import API_KEY, DB_CONFIG
 from sync.models import DatabricksPlanType
+from sync.utils.json import DateTimeEncoderDropMicroseconds
 
 
 @click.group
@@ -76,9 +77,8 @@ def create_workspace_config(
     config = response.result
     if config:
         click.echo(
-            orjson.dumps(
-                config,
-                option=orjson.OPT_INDENT_2 | orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS,
+            json.dumps(
+                config, indent=2, cls=DateTimeEncoderDropMicroseconds
             )
         )
     else:
@@ -92,9 +92,8 @@ def get_workspace_config(workspace_id: str):
     config = config_response.result
     if config:
         click.echo(
-            orjson.dumps(
-                config,
-                option=orjson.OPT_INDENT_2 | orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS,
+            json.dumps(
+                config, indent=2, cls= DateTimeEncoderDropMicroseconds,
             )
         )
     else:
@@ -173,9 +172,8 @@ def update_workspace_config(
         config = update_config_response.result
         if config:
             click.echo(
-                orjson.dumps(
-                    config,
-                    option=orjson.OPT_INDENT_2 | orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS,
+                json.dumps(
+                    config, indent=2, cls=DateTimeEncoderDropMicroseconds,
                 )
             )
         else:
@@ -205,9 +203,8 @@ def reset_webhook_creds(workspace_id: str):
     result = response.result
     if result:
         click.echo(
-            orjson.dumps(
-                result,
-                option=orjson.OPT_INDENT_2 | orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS,
+            json.dumps(
+                result, indent=2, cls=DateTimeEncoderDropMicroseconds,
             )
         )
     else:

--- a/sync/clients/__init__.py
+++ b/sync/clients/__init__.py
@@ -1,7 +1,8 @@
-import httpx
 import json
+from typing import Set, Tuple, Union
+
+import httpx
 from tenacity import Retrying, TryAgain, stop_after_attempt, wait_exponential_jitter
-from typing import Tuple, Union, Set
 
 from sync import __version__
 from sync.utils.json import DateTimeEncoderDropMicroseconds

--- a/sync/clients/__init__.py
+++ b/sync/clients/__init__.py
@@ -1,23 +1,23 @@
 import httpx
-import orjson
+import json
 from tenacity import Retrying, TryAgain, stop_after_attempt, wait_exponential_jitter
 from typing import Tuple, Union, Set
 
 from sync import __version__
+from sync.utils.json import DateTimeEncoderDropMicroseconds
 
 USER_AGENT = f"Sync Library/{__version__} (syncsparkpy)"
 
 
 def encode_json(obj: dict) -> Tuple[dict, str]:
     # "%Y-%m-%dT%H:%M:%SZ"
-    options = orjson.OPT_UTC_Z | orjson.OPT_OMIT_MICROSECONDS | orjson.OPT_NAIVE_UTC
 
-    json = orjson.dumps(obj, option=options).decode()
+    json_obj = json.dumps(obj, cls=DateTimeEncoderDropMicroseconds)
 
     return {
-        "Content-Length": str(len(json)),
+        "Content-Length": str(len(json_obj)),
         "Content-Type": "application/json",
-    }, json
+    }, json_obj
 
 
 class RetryableHTTPClient:

--- a/sync/clients/__init__.py
+++ b/sync/clients/__init__.py
@@ -5,7 +5,7 @@ import httpx
 from tenacity import Retrying, TryAgain, stop_after_attempt, wait_exponential_jitter
 
 from sync import __version__
-from sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 USER_AGENT = f"Sync Library/{__version__} (syncsparkpy)"
 
@@ -13,7 +13,7 @@ USER_AGENT = f"Sync Library/{__version__} (syncsparkpy)"
 def encode_json(obj: dict) -> Tuple[dict, str]:
     # "%Y-%m-%dT%H:%M:%SZ"
 
-    json_obj = json.dumps(obj, cls=DateTimeEncoderDropMicroseconds)
+    json_obj = json.dumps(obj, cls=DateTimeEncoderNaiveUTCDropMicroseconds)
 
     return {
         "Content-Length": str(len(json_obj)),

--- a/sync/utils/json.py
+++ b/sync/utils/json.py
@@ -1,0 +1,23 @@
+import datetime
+from json import JSONEncoder
+
+class DateTimeEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            date = obj
+            if date.tzinfo is None:
+                date = date.replace(tzinfo=datetime.timezone.utc)
+            date = date.isoformat()
+            date = date.replace("+00:00", "Z")
+            return date
+
+class DateTimeEncoderDropMicroseconds(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            date = obj
+            date = date.replace(microsecond=0)
+            if date.tzinfo is None:
+                date = date.replace(tzinfo=datetime.timezone.utc)
+            date = date.isoformat()
+            date = date.replace("+00:00", "Z")
+            return date

--- a/sync/utils/json.py
+++ b/sync/utils/json.py
@@ -2,7 +2,17 @@ import datetime
 from json import JSONEncoder
 
 
-class DateTimeEncoder(JSONEncoder):
+class DefaultDateTimeEncoder(JSONEncoder):
+    # this copies orjson's default behavior when serializing datetimes
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            date = obj
+            date = date.isoformat()
+            return date
+
+
+class DateTimeEncoderNaiveUTC(JSONEncoder):
+    # this copies orjson's behavior when used with the options OPT_UTC_Z and OPT_NAIVE_UTC
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             date = obj
@@ -13,7 +23,8 @@ class DateTimeEncoder(JSONEncoder):
             return date
 
 
-class DateTimeEncoderDropMicroseconds(JSONEncoder):
+class DateTimeEncoderNaiveUTCDropMicroseconds(JSONEncoder):
+    # this copies orjson's behavior when used with the options OPT_OMIT_MICROSECONDS, OPT_UTC_Z, and OPT_NAIVE_UTC
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             date = obj

--- a/sync/utils/json.py
+++ b/sync/utils/json.py
@@ -1,6 +1,7 @@
 import datetime
 from json import JSONEncoder
 
+
 class DateTimeEncoder(JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
@@ -10,6 +11,7 @@ class DateTimeEncoder(JSONEncoder):
             date = date.isoformat()
             date = date.replace("+00:00", "Z")
             return date
+
 
 class DateTimeEncoderDropMicroseconds(JSONEncoder):
     def default(self, obj):

--- a/tests/api/test_predictions.py
+++ b/tests/api/test_predictions.py
@@ -1,4 +1,5 @@
 import json
+
 import respx
 from httpx import Response
 

--- a/tests/api/test_predictions.py
+++ b/tests/api/test_predictions.py
@@ -1,4 +1,4 @@
-import orjson
+import json
 import respx
 from httpx import Response
 
@@ -52,7 +52,7 @@ def test_get_prediction():
     with open("tests/data/predictions_response.json") as predictions_fobj:
         prediction = [
             p
-            for p in orjson.loads(predictions_fobj.read())["result"]
+            for p in json.loads(predictions_fobj.read())["result"]
             if p["prediction_id"] == prediction_id
         ][0]
 

--- a/tests/asyncapi/test_asyncpredictions.py
+++ b/tests/asyncapi/test_asyncpredictions.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 import respx
 from httpx import Response

--- a/tests/asyncapi/test_asyncpredictions.py
+++ b/tests/asyncapi/test_asyncpredictions.py
@@ -1,4 +1,4 @@
-import orjson
+import json
 import pytest
 import respx
 from httpx import Response
@@ -33,7 +33,7 @@ async def test_generate_prediction():
     with open("tests/data/predictions_response.json") as predictions_fobj:
         prediction = [
             p
-            for p in orjson.loads(predictions_fobj.read())["result"]
+            for p in json.loads(predictions_fobj.read())["result"]
             if p["prediction_id"] == prediction_id
         ][0]
     mock_router.get(f"/v1/autotuner/predictions/{prediction_id}").mock(

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -1,11 +1,11 @@
 import copy
 import io
+import json
 from datetime import datetime
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import boto3 as boto
-import json
 from botocore.response import StreamingBody
 from botocore.stub import Stubber
 from httpx import Response
@@ -820,7 +820,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
                 inst for res in MOCK_INSTANCES["Reservations"] for inst in res["Instances"]
             ],
         },
-        cls = DateTimeEncoderDropMicroseconds,
+        cls=DateTimeEncoderDropMicroseconds,
     )
     s3_stubber.add_response(
         "get_object",
@@ -828,7 +828,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
             "ContentType": "application/octet-stream",
             "ContentLength": len(mock_cluster_info_bytes),
             "Body": StreamingBody(
-                io.BytesIO(bytes(mock_cluster_info_bytes, 'utf_8')),
+                io.BytesIO(bytes(mock_cluster_info_bytes, "utf_8")),
                 len(mock_cluster_info_bytes),
             ),
         },

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -813,14 +813,17 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
     s3 = boto.client("s3")
     s3_stubber = Stubber(s3)
 
-    mock_cluster_info_bytes = json.dumps(
-        {
-            "volumes": MOCK_VOLUMES["Volumes"],
-            "instances": [
-                inst for res in MOCK_INSTANCES["Reservations"] for inst in res["Instances"]
-            ],
-        },
-        cls=DateTimeEncoderDropMicroseconds,
+    mock_cluster_info_bytes = bytes(
+        json.dumps(
+            {
+                "volumes": MOCK_VOLUMES["Volumes"],
+                "instances": [
+                    inst for res in MOCK_INSTANCES["Reservations"] for inst in res["Instances"]
+                ],
+            },
+            cls=DateTimeEncoderDropMicroseconds,
+        ),
+        "utf-8",
     )
     s3_stubber.add_response(
         "get_object",
@@ -828,7 +831,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
             "ContentType": "application/octet-stream",
             "ContentLength": len(mock_cluster_info_bytes),
             "Body": StreamingBody(
-                io.BytesIO(bytes(mock_cluster_info_bytes, "utf_8")),
+                io.BytesIO(mock_cluster_info_bytes),
                 len(mock_cluster_info_bytes),
             ),
         },

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -14,7 +14,7 @@ from sync.awsdatabricks import create_prediction_for_run
 from sync.config import DatabricksConf
 from sync.models import DatabricksAPIError, DatabricksError
 from sync.models import Response as SyncResponse
-from sync.utils.json import DateTimeEncoderDropMicroseconds
+from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 MOCK_RUN = {
     "job_id": 12345678910,
@@ -821,7 +821,7 @@ def test_create_prediction_for_run_success_with_cluster_instance_file(respx_mock
                     inst for res in MOCK_INSTANCES["Reservations"] for inst in res["Instances"]
                 ],
             },
-            cls=DateTimeEncoderDropMicroseconds,
+            cls=DateTimeEncoderNaiveUTCDropMicroseconds,
         ),
         "utf-8",
     )

--- a/tests/test_awsemr.py
+++ b/tests/test_awsemr.py
@@ -1,7 +1,7 @@
+import json
 from unittest.mock import Mock, patch
 
 import boto3 as boto
-import json
 from botocore.stub import ANY, Stubber
 from dateutil.parser import parse
 from deepdiff import DeepDiff

--- a/tests/test_awsemr.py
+++ b/tests/test_awsemr.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock, patch
 
 import boto3 as boto
-import orjson
+import json
 from botocore.stub import ANY, Stubber
 from dateutil.parser import parse
 from deepdiff import DeepDiff
@@ -20,7 +20,7 @@ from sync.models import Response
 def test_create_prediction(create_prediction, get_cluster_report):
     with open("tests/data/emr-cluster-report.json") as emr_cluster_report_fobj:
         get_cluster_report.return_value = Response(
-            result=orjson.loads(emr_cluster_report_fobj.read())
+            result=json.loads(emr_cluster_report_fobj.read())
         )
 
     prediction_id = "320554b0-3972-4b7c-9e41-c8efdbdc042c"
@@ -62,7 +62,7 @@ def test_create_prediction(create_prediction, get_cluster_report):
 
 def test_get_cluster_report():
     with open("tests/data/emr-cluster-report.json") as emr_cluster_report_fobj:
-        emr_cluster_report = orjson.loads(emr_cluster_report_fobj.read())
+        emr_cluster_report = json.loads(emr_cluster_report_fobj.read())
 
     cluster_id = emr_cluster_report["Cluster"]["Id"]
     region = emr_cluster_report["Region"]
@@ -103,7 +103,7 @@ def test_get_cluster_report():
 @patch("sync.awsemr.get_project")
 def test_get_project_report(get_project, get_cluster_report):
     with open("tests/data/emr-cluster-report.json") as emr_cluster_report_fobj:
-        cluster_report = orjson.loads(emr_cluster_report_fobj.read())
+        cluster_report = json.loads(emr_cluster_report_fobj.read())
         get_cluster_report.return_value = Response(result=cluster_report)
 
     get_project.return_value = Response(


### PR DESCRIPTION
Passes all current tests, tested a few of the methods that changed individually (locally) but haven't done an exhaustive test of each method. It seems like everything should be working. The package differences are the options for encoding datetimes and the fact that json.dumps is a str and orjson.dumps is bytes. The echo calls in the cli don't care if the output is bytes or strings, and all other dumps calls have been cast to bytes. The utils folder has a custom class that encodes datetimes the same as orjson.