### PR TITLE
PROD-1488: Add user-agent header to all Databricks API calls we make 

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "0.5.3"
+__version__ = "0.6.3"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/clients/__init__.py
+++ b/sync/clients/__init__.py
@@ -8,6 +8,7 @@ from sync import __version__
 from sync.utils.json import DateTimeEncoderNaiveUTCDropMicroseconds
 
 USER_AGENT = f"Sync Library/{__version__} (syncsparkpy)"
+DATABRICKS_USER_AGENT = "sync-gradient"
 
 
 def encode_json(obj: dict) -> Tuple[dict, str]:

--- a/sync/clients/databricks.py
+++ b/sync/clients/databricks.py
@@ -6,7 +6,7 @@ import httpx
 from sync.models import Platform
 
 from ..config import DB_CONFIG
-from . import USER_AGENT, RetryableHTTPClient, encode_json
+from . import DATABRICKS_USER_AGENT, RetryableHTTPClient, encode_json
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class DatabricksClient(RetryableHTTPClient):
         super().__init__(
             client=httpx.Client(
                 base_url=base_url,
-                headers={"User-Agent": USER_AGENT},
+                headers={"User-Agent": DATABRICKS_USER_AGENT},
                 auth=DatabricksAuth(access_token),
             )
         )


### PR DESCRIPTION
# Summary

Add user-agent header “sync-gradient” to Databricks api call

See: “Passing HTTP User Agent Tag for REST API’s” in this doc

https://docs.google.com/document/d/1dfzbMM9bbTQ8WpasDt_B6jZzqOVJGyV5Hdo4G7KBn5Y/edit?usp=sharing

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-1488) (PROD-1488)