### PR TITLE
[PROD-1648] Bugfix describe volumes

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 from time import sleep
-from typing import Iterator, List, Tuple
+from typing import Generator, List, Tuple
 from urllib.parse import urlparse
 
 import boto3 as boto
@@ -481,7 +481,7 @@ def _get_ebs_volumes_for_instances(
 ) -> List[dict]:
     """Get all ebs volumes associated with a list of instance reservations"""
 
-    def get_chunk(instance_ids: list, chunk_size: int) -> Iterator[list]:
+    def get_chunk(instance_ids: list[str], chunk_size: int) -> Generator[list[str]]:
         """
         Splits the instance_ids list into chunks of size determined by chunk_size.
         This function exists to respect thresholds required by the call to


### PR DESCRIPTION
# Summary

There is a bug currently in the library where a call to the `ec2.describe_volumes` only accepts at most 199 items in the `Filters` argument. However, in the case of very large clusters, there can be more than 199 instance ids passed in, which causes the call to fail. 

This PR splits the number of filters to chunks of size no more than 199. 

# Testing Performed

* All unit tests pass
* Dummy projects were kicked off on databricks and the resulting cluster was inspected with the functions calls in both the cases of small number of workers as well as number of workers > 200 and it was verified that the functions calls return the cluster volume data as expected. 

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-1648)