### PR TITLE
Prod-1588 edits to library monitor cluster path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv/*
 .python-version
 .DS_Store
 .venv
+tmp

--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -335,7 +335,7 @@ def monitor_cluster(
     while not spark_context_id:
         # This is largely just a convenience for when this command is run by someone locally
         logger.info("Waiting for cluster startup...")
-        sleep(30)
+        sleep(15)
         cluster = get_default_client().get_cluster(cluster_id)
         spark_context_id = cluster.get("spark_context_id")
 
@@ -420,7 +420,7 @@ def _monitor_cluster(
 
 def _define_write_file(file_key, filesystem, bucket):
     if filesystem == "file":
-        file_path = Path(f"{Path.home()}{file_key}")
+        file_path = Path(file_key)
 
         def ensure_path_exists(report_path: Path):
             logger.info(f"Ensuring path exists for {report_path}")


### PR DESCRIPTION
# Summary

*please add a few lines to give the reviewer context on the changes*
removed the 'home' root path from the local writing of cluster report. Expectation will be that the override contains the full path

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [ x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-1588)

Add any relevant testing examples or screenshots.