### PR TITLE
[PRO-16170] Give ability to set keys, create submission with cluster report, and …

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "1.0.3"
+__version__ = "1.1.0"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -219,7 +219,8 @@ def _get_run_information(
     cluster_report = cluster_report_response.result
     if cluster_report:
         cluster = cluster_report.cluster
-        eventlog = _get_event_log_from_cluster(cluster, tasks)
+        eventlog_response = _get_event_log_from_cluster(cluster, tasks)
+        eventlog = eventlog_response.result
         if eventlog:
             return Response(result=(cluster_report, eventlog))
 

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -219,12 +219,14 @@ def _get_run_information(
     cluster_report = cluster_report_response.result
     if cluster_report:
         cluster = cluster_report.cluster
-        return _get_event_log_from_cluster(cluster, tasks)
+        eventlog = _get_event_log_from_cluster(cluster, tasks)
+        if eventlog:
+            return Response(result=(cluster_report, eventlog))
 
     return cluster_report_response
 
 
-def _get_event_log_from_cluster(cluster: Dict, tasks: List[Dict]) -> Response[str]:
+def _get_event_log_from_cluster(cluster: Dict, tasks: List[Dict]) -> Response[bytes]:
     spark_context_id = _get_run_spark_context_id(tasks)
     end_time = max(task["end_time"] for task in tasks)
     eventlog_response = _get_eventlog(cluster, spark_context_id.result, end_time)

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -18,7 +18,14 @@ import boto3 as boto
 from sync.api import projects
 from sync.clients.databricks import get_default_client
 from sync.config import CONFIG  # noqa F401
-from sync.models import DatabricksAPIError, DatabricksClusterReport, DatabricksError, Response
+from sync.models import (
+    DatabricksAPIError,
+    DatabricksClusterReport,
+    DatabricksError,
+    DatabricksComputeType,
+    DatabricksPlanType,
+    Response
+)
 from sync.utils.dbfs import format_dbfs_filepath, read_dbfs_file
 
 logger = logging.getLogger(__name__)
@@ -56,10 +63,14 @@ def get_cluster(cluster_id: str) -> Response[dict]:
     return Response(result=cluster)
 
 
-def create_submission_with_cluster_report(
+def create_submission_with_cluster_info(
     run_id: str,
     project_id: str,
-    cluster_report: DatabricksClusterReport
+    cluster: Dict,
+    cluster_info: Dict,
+    cluster_activity_events: Dict,
+    plan_type: DatabricksPlanType,
+    compute_type: DatabricksComputeType,
 ) -> Response[str]:
     """Create a Submission for the specified Databricks run given a cluster report"""
 
@@ -85,7 +96,14 @@ def create_submission_with_cluster_report(
 
     _, tasks = cluster_tasks
 
-    cluster = cluster_report.cluster
+    cluster_report = _create_cluster_report(
+        cluster=cluster,
+        cluster_info=cluster_info,
+        cluster_activity_events=cluster_activity_events,
+        tasks=tasks,
+        plan_type=plan_type,
+        compute_type=compute_type
+    )
     eventlog = _get_event_log_from_cluster(cluster, tasks).result
 
     return projects.create_project_submission_with_eventlog_bytes(
@@ -283,6 +301,17 @@ def _get_cluster_report(
     compute_type: str,
     allow_incomplete: bool,
 ) -> Response[DatabricksClusterReport]:
+    raise NotImplementedError()
+
+
+def _create_cluster_report(
+        cluster: dict,
+        cluster_info: dict,
+        cluster_activity_events: dict,
+        tasks: List[dict],
+        plan_type: DatabricksPlanType,
+        compute_type: DatabricksComputeType
+) -> DatabricksClusterReport:
     raise NotImplementedError()
 
 

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -56,6 +56,47 @@ def get_cluster(cluster_id: str) -> Response[dict]:
     return Response(result=cluster)
 
 
+def create_submission_with_cluster_report(
+    run_id: str,
+    project_id: str,
+    cluster_report: DatabricksClusterReport
+) -> Response[str]:
+    """Create a Submission for the specified Databricks run given a cluster report"""
+
+    run = get_default_client().get_run(run_id)
+
+    if "error_code" in run:
+        return Response(error=DatabricksAPIError(**run))
+
+    project_response = projects.get_project(project_id)
+    if project_response.error:
+        return project_response
+    cluster_path = project_response.result.get("cluster_path")
+
+    project_cluster_tasks = _get_project_cluster_tasks(run, project_id, cluster_path)
+
+    cluster_tasks = project_cluster_tasks.get(project_id)
+    if not cluster_tasks:
+        return Response(
+            error=DatabricksError(
+                message=f"Failed to locate cluster in run {run_id} for project {project_id}"
+            )
+        )
+
+    _, tasks = cluster_tasks
+
+    cluster = cluster_report.cluster
+    eventlog = _get_event_log_from_cluster(cluster, tasks).result
+
+    return projects.create_project_submission_with_eventlog_bytes(
+        get_default_client().get_platform(),
+        cluster_report.dict(exclude_none=True),
+        "eventlog.zip",
+        eventlog,
+        project_id,
+    )
+
+
 def create_submission_for_run(
     run_id: str,
     plan_type: str,
@@ -160,17 +201,22 @@ def _get_run_information(
     cluster_report = cluster_report_response.result
     if cluster_report:
         cluster = cluster_report.cluster
-        spark_context_id = _get_run_spark_context_id(tasks)
-        end_time = max(task["end_time"] for task in tasks)
-        eventlog_response = _get_eventlog(cluster, spark_context_id.result, end_time)
+        return _get_event_log_from_cluster(cluster, tasks)
 
-        eventlog = eventlog_response.result
-        if eventlog:
-            # TODO - allow submissions w/out eventlog. Best way to make eventlog optional?..
-            return Response(result=(cluster_report, eventlog))
-
-        return eventlog_response
     return cluster_report_response
+
+
+def _get_event_log_from_cluster(cluster: Dict, tasks: List[Dict]) -> Response[str]:
+    spark_context_id = _get_run_spark_context_id(tasks)
+    end_time = max(task["end_time"] for task in tasks)
+    eventlog_response = _get_eventlog(cluster, spark_context_id.result, end_time)
+
+    eventlog = eventlog_response.result
+    if eventlog:
+        # TODO - allow submissions w/out eventlog. Best way to make eventlog optional?..
+        return Response(result=eventlog)
+
+    return eventlog_response  # return eventlog response with errors
 
 
 def get_cluster_report(
@@ -1493,7 +1539,7 @@ def _get_eventlog(
         return Response(error=DatabricksError(message=f"Unknown log destination: {filesystem}"))
 
 
-def _get_all_cluster_events(cluster_id: str):
+def get_all_cluster_events(cluster_id: str):
     """Fetches all ClusterEvents for a given Databricks cluster, optionally within a time window.
     Pages will be followed and returned as 1 object
     """

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -354,7 +354,8 @@ def monitor_cluster(
     cluster_id: str,
     polling_period: int = 20,
     cluster_report_destination_override: dict = None,
-) -> int:
+    kill_on_termination: bool = False,
+) -> None:
     cluster = get_default_client().get_cluster(cluster_id)
     spark_context_id = cluster.get("spark_context_id")
 
@@ -369,8 +370,6 @@ def monitor_cluster(
     if cluster_report_destination_override:
         filesystem = cluster_report_destination_override.get("filesystem", filesystem)
         base_prefix = cluster_report_destination_override.get("base_prefix", base_prefix)
-
-    kill_on_termination: bool = cluster_report_destination_override is not None
 
     if log_url or cluster_report_destination_override:
         _monitor_cluster(

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -22,7 +22,7 @@ from sync._databricks import (
     create_cluster,
     create_run,
     create_submission_for_run,
-    create_submission_with_cluster_report,
+    create_submission_with_cluster_info,
     get_cluster,
     get_cluster_report,
     get_project_cluster,
@@ -49,6 +49,8 @@ from sync.models import (
     AccessStatusCode,
     AWSDatabricksClusterReport,
     DatabricksError,
+    DatabricksPlanType,
+    DatabricksComputeType,
     Response,
 )
 from sync.utils.dbfs import format_dbfs_filepath, write_dbfs_file
@@ -58,7 +60,7 @@ __all__ = [
     "get_access_report",
     "run_and_record_job",
     "create_submission_for_run",
-    "create_submission_with_cluster_report",
+    "create_submission_with_cluster_info",
     "get_cluster_report",
     "get_all_cluster_events",
     "monitor_cluster",
@@ -235,12 +237,33 @@ def _get_cluster_report(
     )
 
 
+def _create_cluster_report(
+        cluster: dict,
+        cluster_info: dict,
+        cluster_activity_events: dict,
+        tasks: List[dict],
+        plan_type: DatabricksPlanType,
+        compute_type: DatabricksComputeType
+) -> AWSDatabricksClusterReport:
+    return AWSDatabricksClusterReport(
+        plan_type=plan_type,
+        compute_type=compute_type,
+        cluster=cluster,
+        cluster_events=cluster_activity_events,
+        tasks=tasks,
+        instances=cluster_info.get("instances"),
+        volumes=cluster_info.get("volumes"),
+        instance_timelines=cluster_info.get("instance_timelines")
+    )
+
+
 if getattr(sync._databricks, "__claim", __name__) != __name__:
     raise RuntimeError(
         "Databricks modules for different cloud providers cannot be used in the same context"
     )
 
 sync._databricks._get_cluster_report = _get_cluster_report
+sync._databricks._create_cluster_report = _create_cluster_report
 setattr(sync._databricks, "__claim", __name__)
 
 

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -331,7 +331,7 @@ def monitor_cluster(
     cluster_id: str,
     polling_period: int = 20,
     cluster_report_destination_override: dict = None,
-) -> None:
+) -> int:
     cluster = get_default_client().get_cluster(cluster_id)
     spark_context_id = cluster.get("spark_context_id")
 
@@ -356,6 +356,8 @@ def monitor_cluster(
         )
     else:
         logger.warning("Unable to monitor cluster due to missing cluster log destination - exiting")
+
+    return spark_context_id
 
 
 def _monitor_cluster(

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -238,12 +238,12 @@ def _get_cluster_report(
 
 
 def _create_cluster_report(
-        cluster: dict,
-        cluster_info: dict,
-        cluster_activity_events: dict,
-        tasks: List[dict],
-        plan_type: DatabricksPlanType,
-        compute_type: DatabricksComputeType
+    cluster: dict,
+    cluster_info: dict,
+    cluster_activity_events: dict,
+    tasks: List[dict],
+    plan_type: DatabricksPlanType,
+    compute_type: DatabricksComputeType,
 ) -> AWSDatabricksClusterReport:
     return AWSDatabricksClusterReport(
         plan_type=plan_type,
@@ -253,7 +253,7 @@ def _create_cluster_report(
         tasks=tasks,
         instances=cluster_info.get("instances"),
         volumes=cluster_info.get("volumes"),
-        instance_timelines=cluster_info.get("instance_timelines")
+        instance_timelines=cluster_info.get("instance_timelines"),
     )
 
 
@@ -379,8 +379,6 @@ def monitor_cluster(
         )
     else:
         logger.warning("Unable to monitor cluster due to missing cluster log destination - exiting")
-
-    return spark_context_id
 
 
 def _monitor_cluster(

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 import sync._databricks
 from sync._databricks import (
     _cluster_log_destination,
-    _get_all_cluster_events,
+    get_all_cluster_events,
     _get_cluster_instances_from_dbfs,
     _update_monitored_timelines,
     _wait_for_cluster_termination,
@@ -22,6 +22,7 @@ from sync._databricks import (
     create_cluster,
     create_run,
     create_submission_for_run,
+    create_submission_with_cluster_report,
     get_cluster,
     get_cluster_report,
     get_project_cluster,
@@ -57,7 +58,9 @@ __all__ = [
     "get_access_report",
     "run_and_record_job",
     "create_submission_for_run",
+    "create_submission_with_cluster_report",
     "get_cluster_report",
+    "get_all_cluster_events",
     "monitor_cluster",
     "create_cluster",
     "get_cluster",
@@ -217,7 +220,7 @@ def _get_cluster_report(
     else:
         timelines = timeline_response.result
 
-    cluster_events = _get_all_cluster_events(cluster_id)
+    cluster_events = get_all_cluster_events(cluster_id)
     return Response(
         result=AWSDatabricksClusterReport(
             plan_type=plan_type,

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -25,7 +25,7 @@ from sync._databricks import (
     create_cluster,
     create_run,
     create_submission_for_run,
-    create_submission_with_cluster_report,
+    create_submission_with_cluster_info,
     get_cluster,
     get_cluster_report,
     get_project_cluster,
@@ -51,6 +51,8 @@ from sync.models import (
     AccessStatusCode,
     AzureDatabricksClusterReport,
     DatabricksError,
+    DatabricksPlanType,
+    DatabricksComputeType,
     Response,
 )
 from sync.utils.dbfs import format_dbfs_filepath, write_dbfs_file
@@ -63,7 +65,7 @@ __all__ = [
     "create_cluster",
     "get_cluster",
     "create_submission_for_run",
-    "create_submission_with_cluster_report",
+    "create_submission_with_cluster_info",
     "get_cluster_report",
     "get_all_cluster_events",
     "handle_successful_job_run",
@@ -226,6 +228,25 @@ def _get_cluster_report(
     )
 
 
+def _create_cluster_report(
+        cluster: dict,
+        cluster_info: dict,
+        cluster_activity_events: dict,
+        tasks: List[dict],
+        plan_type: DatabricksPlanType,
+        compute_type: DatabricksComputeType
+) -> AzureDatabricksClusterReport:
+    return AzureDatabricksClusterReport(
+        plan_type=plan_type,
+        compute_type=compute_type,
+        cluster=cluster,
+        cluster_events=cluster_activity_events,
+        tasks=tasks,
+        instances=cluster_info.get("instances"),
+        instance_timelines=cluster_info.get("timelines")
+    )
+
+
 if getattr(sync._databricks, "__claim", __name__) != __name__:
     # Unless building documentation you can't load both databricks modules in the same program
     if not sys.argv[0].endswith("sphinx-build"):
@@ -234,6 +255,7 @@ if getattr(sync._databricks, "__claim", __name__) != __name__:
         )
 
 sync._databricks._get_cluster_report = _get_cluster_report
+sync._databricks._create_cluster_report = _create_cluster_report
 setattr(sync._databricks, "__claim", __name__)
 
 

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -15,7 +15,7 @@ from azure.mgmt.resource import ResourceManagementClient
 import sync._databricks
 from sync._databricks import (
     _cluster_log_destination,
-    _get_all_cluster_events,
+    get_all_cluster_events,
     _get_cluster_instances_from_dbfs,
     _update_monitored_timelines,
     _wait_for_cluster_termination,
@@ -25,6 +25,7 @@ from sync._databricks import (
     create_cluster,
     create_run,
     create_submission_for_run,
+    create_submission_with_cluster_report,
     get_cluster,
     get_cluster_report,
     get_project_cluster,
@@ -62,7 +63,9 @@ __all__ = [
     "create_cluster",
     "get_cluster",
     "create_submission_for_run",
+    "create_submission_with_cluster_report",
     "get_cluster_report",
+    "get_all_cluster_events",
     "handle_successful_job_run",
     "record_run",
     "get_project_cluster",
@@ -209,7 +212,7 @@ def _get_cluster_report(
         else:
             return instances
 
-    cluster_events = _get_all_cluster_events(cluster_id)
+    cluster_events = get_all_cluster_events(cluster_id)
     return Response(
         result=AzureDatabricksClusterReport(
             plan_type=plan_type,

--- a/sync/config.py
+++ b/sync/config.py
@@ -116,6 +116,14 @@ def get_api_key() -> APIKey:
     return _api_key
 
 
+def set_api_key(api_key: APIKey):
+    global _api_key
+    if _api_key is not None:
+        raise RuntimeError("Sync API key/secret has already been set and the library does not support resetting "
+                           "credentials")
+    _api_key = api_key
+
+
 def get_config() -> Configuration:
     """Gets configuration
 
@@ -136,6 +144,14 @@ def get_databricks_config() -> DatabricksConf:
         except ValueError:
             pass
     return _db_config
+
+
+def set_databricks_config(db_config: DatabricksConf):
+    global _db_config
+    if _db_config is not None:
+        raise RuntimeError("Databricks config has already been set and the library does not support resetting "
+                           "credentials")
+    _db_config = db_config
 
 
 CONFIG: Configuration

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -39,14 +39,14 @@ class TestMonitorCluster(unittest.TestCase):
 
         expected_log_destination_override = ("s3://bucket/path", "file", "bucket", "test_file_path")
         mock_monitor_cluster.assert_called_with(
-            expected_log_destination_override, "0101-214342-tpi6qdp2", 1443449481634833945, 1
+            expected_log_destination_override, "0101-214342-tpi6qdp2", 1443449481634833945, 1, True
         )
 
         mock_cluster_log_destination.return_value = (None, "s3", None, "path")
         monitor_cluster("0101-214342-tpi6qdp2", 1, cluster_report_destination_override)
         expected_log_destination_override = (None, "file", None, "test_file_path")
         mock_monitor_cluster.assert_called_with(
-            expected_log_destination_override, "0101-214342-tpi6qdp2", 1443449481634833945, 1
+            expected_log_destination_override, "0101-214342-tpi6qdp2", 1443449481634833945, 1, True
         )
 
     def test_monitor_cluster_without_override(
@@ -69,4 +69,5 @@ class TestMonitorCluster(unittest.TestCase):
             "0101-214342-tpi6qdp2",
             1443449481634833945,
             1,
+            False,
         )

--- a/tests/test_awsdatabricks.py
+++ b/tests/test_awsdatabricks.py
@@ -35,7 +35,7 @@ class TestMonitorCluster(unittest.TestCase):
             "base_prefix": "test_file_path",
         }
 
-        monitor_cluster("0101-214342-tpi6qdp2", 1, cluster_report_destination_override)
+        monitor_cluster("0101-214342-tpi6qdp2", 1, cluster_report_destination_override, True)
 
         expected_log_destination_override = ("s3://bucket/path", "file", "bucket", "test_file_path")
         mock_monitor_cluster.assert_called_with(
@@ -43,7 +43,7 @@ class TestMonitorCluster(unittest.TestCase):
         )
 
         mock_cluster_log_destination.return_value = (None, "s3", None, "path")
-        monitor_cluster("0101-214342-tpi6qdp2", 1, cluster_report_destination_override)
+        monitor_cluster("0101-214342-tpi6qdp2", 1, cluster_report_destination_override, True)
         expected_log_destination_override = (None, "file", None, "test_file_path")
         mock_monitor_cluster.assert_called_with(
             expected_log_destination_override, "0101-214342-tpi6qdp2", 1443449481634833945, 1, True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,42 +1,44 @@
 import unittest
 import pytest
-
+from unittest.mock import patch
 from sync import config
 
 
 class TestConfig(unittest.TestCase):
-    def test_set_api_key_twice_raises_an_error(
-        self
+    @patch("sync.config._api_key")
+    def test_set_api_key_when_api_key_exists_raises_an_error(
+        self,
+        mock_api_key
     ):
-        mock_api_key = config.APIKey(
+        mock_api_key.return_value = config.APIKey(
             api_key_id="mock_api_key_id",
             api_key_secret="mock_api_key_secret"
         )
-        config.set_api_key(mock_api_key)
 
-        mock_api_key_2 = config.APIKey(
+        new_api_key = config.APIKey(
             api_key_id="mock_api_key_id_2",
             api_key_secret="mock_api_key_secret_2"
         )
 
         with pytest.raises(RuntimeError):
-            config.set_api_key(mock_api_key_2)
+            config.set_api_key(new_api_key)
 
-    def test_set_databricks_config_twice_raises_an_error(
-        self
+    @patch("sync.config._db_config")
+    def test_set_databricks_config_when_db_config_exists_raises_an_error(
+        self,
+        mock_db_config
     ):
-        mock_dbx_config = config.DatabricksConf(
+        mock_db_config.return_value = config.DatabricksConf(
             host="https://fakedbx-host.com",
             token="dsapifaketoken",
             aws_region_name="us-east-1"
         )
-        config.set_databricks_config(mock_dbx_config)
 
-        mock_dbx_config_2 = config.DatabricksConf(
+        new_db_config = config.DatabricksConf(
             host="https://fakedbx-host-2.com",
             token="dsapifaketoken2",
             aws_region_name="us-east-2"
         )
 
         with pytest.raises(RuntimeError):
-            config.set_databricks_config(mock_dbx_config_2)
+            config.set_databricks_config(new_db_config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+import unittest
+import pytest
+
+from sync import config
+
+
+class TestConfig(unittest.TestCase):
+    def test_set_api_key_twice_raises_an_error(
+        self
+    ):
+        mock_api_key = config.APIKey(
+            api_key_id="mock_api_key_id",
+            api_key_secret="mock_api_key_secret"
+        )
+        config.set_api_key(mock_api_key)
+
+        mock_api_key_2 = config.APIKey(
+            api_key_id="mock_api_key_id_2",
+            api_key_secret="mock_api_key_secret_2"
+        )
+
+        with pytest.raises(RuntimeError):
+            config.set_api_key(mock_api_key_2)
+
+    def test_set_databricks_config_twice_raises_an_error(
+        self
+    ):
+        mock_dbx_config = config.DatabricksConf(
+            host="https://fakedbx-host.com",
+            token="dsapifaketoken",
+            aws_region_name="us-east-1"
+        )
+        config.set_databricks_config(mock_dbx_config)
+
+        mock_dbx_config_2 = config.DatabricksConf(
+            host="https://fakedbx-host-2.com",
+            token="dsapifaketoken2",
+            aws_region_name="us-east-2"
+        )
+
+        with pytest.raises(RuntimeError):
+            config.set_databricks_config(mock_dbx_config_2)


### PR DESCRIPTION
# Summary

* Expose get_cluster_activity_events as a public function
* Add mechanism to stop monitor cluster polling when we are hosting it until the cluster has reached a termination state
* Create submission with all the cluster report info coming in from outside the library

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-) (add id)

Add any relevant testing examples or screenshots.