### PR TITLE
[PROD-1659] Add periodicity type to project create

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,4 +1,4 @@
 """Library for leveraging the power of Sync"""
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -37,7 +37,7 @@ def create_project(
     prediction_params: dict = None,
     app_id: str = None,
     optimize_instance_size: bool = False,
-    project_periodicity: str = None,
+    project_periodicity_type: str = None,
 ) -> Response[dict]:
     """Creates a Sync project for tracking and optimizing Apache Spark applications
 
@@ -78,7 +78,7 @@ def create_project(
                 "prediction_params": prediction_params,
                 "app_id": app_id,
                 "optimize_instance_size": optimize_instance_size,
-                "project_periodicity": project_periodicity,
+                "project_periodicity_type": project_periodicity_type,
             }
         )
     )
@@ -105,7 +105,7 @@ def update_project(
     auto_apply_recs: bool = None,
     prediction_params: dict = None,
     optimize_instance_size: bool = None,
-    project_periodicity: str = None,
+    project_periodicity_type: str = None,
 ) -> Response[dict]:
     """Updates a project's mutable properties
 
@@ -144,8 +144,8 @@ def update_project(
         project_update["workspace_id"] = workspace_id
     if optimize_instance_size:
         project_update["optimize_instance_size"] = optimize_instance_size
-    if project_periodicity:
-        project_update["project_periodicity"] = project_periodicity
+    if project_periodicity_type:
+        project_update["project_periodicity_type"] = project_periodicity_type
 
     return Response(
         **get_default_client().update_project(

--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -37,7 +37,7 @@ def create_project(
     prediction_params: dict = None,
     app_id: str = None,
     optimize_instance_size: bool = False,
-    project_periodicity: str = None
+    project_periodicity: str = None,
 ) -> Response[dict]:
     """Creates a Sync project for tracking and optimizing Apache Spark applications
 
@@ -78,7 +78,7 @@ def create_project(
                 "prediction_params": prediction_params,
                 "app_id": app_id,
                 "optimize_instance_size": optimize_instance_size,
-                "project_periodicity": project_periodicity
+                "project_periodicity": project_periodicity,
             }
         )
     )
@@ -105,7 +105,7 @@ def update_project(
     auto_apply_recs: bool = None,
     prediction_params: dict = None,
     optimize_instance_size: bool = None,
-    project_periodicity: str = None
+    project_periodicity: str = None,
 ) -> Response[dict]:
     """Updates a project's mutable properties
 

--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -37,6 +37,7 @@ def create_project(
     prediction_params: dict = None,
     app_id: str = None,
     optimize_instance_size: bool = False,
+    project_periodicity: str = None
 ) -> Response[dict]:
     """Creates a Sync project for tracking and optimizing Apache Spark applications
 
@@ -77,6 +78,7 @@ def create_project(
                 "prediction_params": prediction_params,
                 "app_id": app_id,
                 "optimize_instance_size": optimize_instance_size,
+                "project_periodicity": project_periodicity
             }
         )
     )
@@ -102,7 +104,8 @@ def update_project(
     app_id: str = None,
     auto_apply_recs: bool = None,
     prediction_params: dict = None,
-    optimize_instance_size=None,
+    optimize_instance_size: bool = None,
+    project_periodicity: str = None
 ) -> Response[dict]:
     """Updates a project's mutable properties
 
@@ -141,6 +144,8 @@ def update_project(
         project_update["workspace_id"] = workspace_id
     if optimize_instance_size:
         project_update["optimize_instance_size"] = optimize_instance_size
+    if project_periodicity:
+        project_update["project_periodicity"] = project_periodicity
 
     return Response(
         **get_default_client().update_project(


### PR DESCRIPTION
# Summary

This PR adds a new field to the create and update project endpoints to include `project_periodicity`. This new enum will be added to the db and the rest of the backend simultaneously with the landing of this PR. 

See the JIRA ticket below for more details. 

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-1659)