### PR TITLE
PROD-1812: Docs Versioning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,15 +2,18 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-from sync import __version__
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import sync
 
 rst_epilog = """
-.. version replace:: {project_version}
+.. |version| replace:: {project_version}
 """.format(
-    project_version=__version__,
+    project_version=sync.__version__,
 )
 
 project = "Sync Library"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,11 +5,17 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+from sync import __version__
+
+rst_epilog = """
+.. version replace:: {project_version}
+""".format(
+    project_version=__version__,
+)
 
 project = "Sync Library"
 copyright = "2022, Sync Computing"
 author = "Sync Computing"
-release = "0.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -18,7 +24,6 @@ extensions = ["sphinx.ext.autodoc", "sphinx.ext.todo"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,14 +1,15 @@
+import sys
+import os
+import sync
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-import sys
-import os
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-import sync
 
 rst_epilog = """
 .. |version| replace:: {project_version}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,14 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+
 Welcome to the Sync Library!
 ============================
+
+.. note::
+  This information applies to Sync Library and CLI versions |version| and above, which are in public preview. To find your version of the Sync CLI run:
+
+  ``sync-cli --version``
 
 .. toctree::
    :maxdepth: 2

--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,5 +1,5 @@
 """Library for leveraging the power of Sync"""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
# Summary

The Sync library docs page has v0.0.1 in the title. However, the actual version of the Sync library is [1.4.0](https://github.com/synccomputingcode/syncsparkpy/releases/tag/v1.4.0).

https://synccomputingcode.github.io/syncsparkpy/index.html 

<title>Welcome to the Sync Library! &#8212; Sync Library 0.0.1 documentation</title>

Expected

- Version is removed from the title.
- An info box at the top of the main page shows the latest version of the library / CLI 
    - For example, see [Databricks CLI page](https://docs.databricks.com/en/dev-tools/cli/index.html)


## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-1812) (PROD-1812)

Add any relevant testing examples or screenshots.