### PR TITLE
[PROD-1968] Add monitor_once functionality to library

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,5 +1,5 @@
 """Library for leveraging the power of Sync"""
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/awsdatabricks.py
+++ b/sync/awsdatabricks.py
@@ -268,7 +268,6 @@ setattr(sync._databricks, "__claim", __name__)
 
 
 def _load_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict]]:
-
     cluster_info = None
     cluster_id = None
     cluster_log_dest = _cluster_log_destination(cluster)
@@ -312,7 +311,6 @@ def _load_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict
 
 
 def _get_aws_cluster_info(cluster: dict) -> Tuple[Response[dict], Response[dict], Response[dict]]:
-
     aws_region_name = DB_CONFIG.aws_region_name
 
     cluster_info, cluster_id = _load_aws_cluster_info(cluster)
@@ -394,7 +392,6 @@ def _monitor_cluster(
     kill_on_termination: bool = False,
     write_function=None,
 ) -> None:
-
     (log_url, filesystem, bucket, base_prefix) = cluster_log_destination
     # If the event log destination is just a *bucket* without any sub-path, then we don't want to include
     #  a leading `/` in our Prefix (which will make it so that we never actually find the event log), so
@@ -458,20 +455,14 @@ def _monitor_cluster(
         sleep(polling_period)
 
 
-def monitor_once(
-    cluster_id: str,
-    all_inst_by_id={},
-    active_timelines_by_id={},
-    retired_timelines=[],
-    recorded_volumes_by_id={},
-):
+def monitor_once(cluster_id: str, in_progress_cluster={}):
+    all_inst_by_id = in_progress_cluster.get("all_inst_by_id") or {}
+    active_timelines_by_id = in_progress_cluster.get("active_timelines_by_id") or {}
+    retired_timelines = in_progress_cluster.get("retired_timelines") or []
+    recorded_volumes_by_id = in_progress_cluster.get("recorded_volumes_by_id") or {}
+
     aws_region_name = DB_CONFIG.aws_region_name
     ec2 = boto.client("ec2", region_name=aws_region_name)
-
-    # all_inst_by_id = {}
-    # active_timelines_by_id = {}
-    # retired_timelines = []
-    # recorded_volumes_by_id = {}
 
     current_insts = _get_ec2_instances(cluster_id, ec2)
     recorded_volumes_by_id.update(
@@ -541,7 +532,6 @@ def _define_write_file(file_key, filesystem, bucket, write_function):
 
 
 def _get_ec2_instances(cluster_id: str, ec2_client: "botocore.client.ec2") -> List[dict]:
-
     filters = [
         {"Name": "tag:Vendor", "Values": ["Databricks"]},
         {"Name": "tag:ClusterId", "Values": [cluster_id]},

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -90,7 +90,6 @@ __all__ = [
     "apply_project_recommendation",
 ]
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -288,7 +287,6 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
     # If this cluster does not have the "Sync agent" configured, attempt a best-effort snapshot of the instances that
     #  are associated with this cluster
     if not cluster_instances:
-
         resource_group_name = _get_databricks_resource_group_name()
 
         compute = _get_azure_client(ComputeManagementClient)
@@ -423,9 +421,11 @@ def _monitor_cluster(
         sleep(polling_period)
 
 
-def monitor_once(
-    cluster_id: str, all_vms_by_id={}, active_timelines_by_id={}, retired_timelines=[]
-):
+def monitor_once(cluster_id: str, in_progress_cluster={}):
+    all_vms_by_id = in_progress_cluster.get("all_vms_by_id") or {}
+    active_timelines_by_id = in_progress_cluster.get("active_timelines_by_id") or {}
+    retired_timelines = in_progress_cluster.get("retired_timelines") or []
+
     resource_group_name = _get_databricks_resource_group_name()
     if not resource_group_name:
         logger.warning("Failed to find Databricks managed resource group")
@@ -496,7 +496,6 @@ def _get_databricks_resource_group_name() -> str:
 _azure_credential = None
 _azure_subscription_id = None
 
-
 AzureClient = TypeVar("AzureClient")
 
 
@@ -546,7 +545,6 @@ def _get_azure_subscription_id():
 def _get_running_vms_by_id(
     compute: AzureClient, resource_group_name: Optional[str], cluster_id: str
 ) -> Dict[str, dict]:
-
     if resource_group_name:
         vms = compute.virtual_machines.list(resource_group_name=resource_group_name)
     else:


### PR DESCRIPTION
# Summary

Add monitor once function so we can re-enqueue instances, volumes, timelines over many celery tasks

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-) (add id)

Add any relevant testing examples or screenshots.