### PR TITLE
PROD-2124 Use v2 /submissions endpoint

### DIFF
--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -132,7 +132,7 @@ class SyncClient(RetryableHTTPClient):
     def get_project_submissions(self, project_id: str, params: dict = None) -> dict:
         return self._send(
             self._client.build_request(
-                "GET", f"/v1/projects/{project_id}/submissions-v2", params=params
+                "GET", f"/v1/projects/{project_id}/paged/submissions", params=params
             )
         )
 

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -132,7 +132,7 @@ class SyncClient(RetryableHTTPClient):
     def get_project_submissions(self, project_id: str, params: dict = None) -> dict:
         return self._send(
             self._client.build_request(
-                "GET", f"/v1/projects/{project_id}/submissions", params=params
+                "GET", f"/v1/projects/{project_id}/submissions-v2", params=params
             )
         )
 


### PR DESCRIPTION
[PROD-2124](https://synccomputing.atlassian.net/browse/PROD-2124)
 
Switch to v2 endpoint so we can maintain the old endpoint for backwards compatibility

[PROD-2124]: https://synccomputing.atlassian.net/browse/PROD-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ