### PR TITLE
fix cluster report creation bug

### DIFF
--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -292,11 +292,6 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
         compute = _get_azure_client(ComputeManagementClient)
         if resource_group_name:
             vms = compute.virtual_machines.list(resource_group_name=resource_group_name)
-
-            for vm in vms:
-                compute.virtual_machines.instance_view(
-                    resource_group_name=resource_group_name,
-                )
         else:
             logger.warning("Failed to find Databricks managed resource group")
             vms = compute.virtual_machines.list_all()
@@ -310,7 +305,7 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
             ]
         }
 
-    if not cluster_instances:
+    if not cluster_instances.get('instances', None):
         no_instances_message = (
             f"Unable to find any active or recently terminated instances for cluster `{cluster_id}`. "
             + "Please refer to the following documentation for options on how to address this - "

--- a/sync/azuredatabricks.py
+++ b/sync/azuredatabricks.py
@@ -290,12 +290,6 @@ def _get_cluster_instances(cluster: dict) -> Response[dict]:
             )
             return Response(error=DatabricksError(message=no_instances_message))
 
-    else:
-        no_cluster_logs_message = (
-            f"No cluster log configuration has been set for cluster `{cluster_id}`. "
-        )
-        return Response(error=DatabricksError(message=no_cluster_logs_message))
-
     return Response(result=cluster_instances)
 
 


### PR DESCRIPTION
# Summary

Occasionally, when the dbx api would fail for miscellaneous reasons, we would enter a section of code on cluster creation that was causing an exception. I've fixed the exception but would like to note that this code path will no longer yield a submission because we'll be missing an instance timeline and the other sync-specific information. It's no longer sufficient for us to grab a best guess snapshot. Should we keep this code in here so we at least get all available data in the cluster report saved to s3 or should we take these code paths out for aws/azure because this cluster report is deprecated?

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-2005)
Add any relevant testing examples or screenshots.