### PR TITLE
[PROD-2276] Move CachedToken class to not break globals and imports

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,5 +1,5 @@
 """Library for leveraging the power of Sync"""
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/clients/cache.py
+++ b/sync/clients/cache.py
@@ -1,6 +1,10 @@
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union, Callable, Type
+from pathlib import Path
+import json
+
+from platformdirs import user_cache_dir
 
 logger = logging.getLogger(__name__)
 
@@ -43,3 +47,57 @@ class CachedToken:
 
     def _get_cached_token(self) -> Optional[Tuple[str, datetime]]:
         raise NotImplementedError
+
+
+class FileCachedToken(CachedToken):
+    def __init__(self):
+        self._cache_file = Path(user_cache_dir("syncsparkpy")) / "auth.json"
+
+        super().__init__()
+
+    def _get_cached_token(self) -> Optional[Tuple[str, datetime]]:
+        # Cache is optional, we can fail to read it and not worry
+        if self._cache_file.exists():
+            try:
+                cached_token = json.loads(self._cache_file.read_text())
+                cached_access_token = cached_token["access_token"]
+                cached_expiry = datetime.fromisoformat(cached_token["expires_at_utc"])
+                return cached_access_token, cached_expiry
+            except Exception as e:
+                logger.warning(
+                    f"Failed to read cached access token @ {self._cache_file}", exc_info=e
+                )
+
+        return None
+
+    def _set_cached_token(self) -> None:
+        # Cache is optional, we can fail to read it and not worry
+        try:
+            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
+            self._cache_file.write_text(
+                json.dumps(
+                    {
+                        "access_token": self._access_token,
+                        "expires_at_utc": self._access_token_expires_at_utc.isoformat(),
+                    }
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to write cached access token @ {self._cache_file}", exc_info=e
+            )
+
+
+# Putting this here instead of config.py because circular imports and typing.
+ACCESS_TOKEN_CACHE_CLS_TYPE = Union[Type[CachedToken], Callable[[], CachedToken]]
+_access_token_cache_cls: ACCESS_TOKEN_CACHE_CLS_TYPE = FileCachedToken  # Default to local file caching.
+
+
+def set_access_token_cache_cls(access_token_cache_cls: ACCESS_TOKEN_CACHE_CLS_TYPE) -> None:
+    global _access_token_cache_cls
+    _access_token_cache_cls = access_token_cache_cls
+
+
+def get_access_token_cache_cache() -> ACCESS_TOKEN_CACHE_CLS_TYPE:
+    global _access_token_cache_cls
+    return _access_token_cache_cls

--- a/sync/clients/cache.py
+++ b/sync/clients/cache.py
@@ -1,0 +1,45 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class CachedToken:
+    def __init__(self, token_refresh_before_expiry=timedelta(seconds=30)):
+        self.token_refresh_before_expiry = token_refresh_before_expiry
+
+        cache = self._get_cached_token()
+
+        if cache:
+            self._access_token, self._access_token_expires_at_utc = cache
+        else:
+            self._access_token: Optional[str] = None
+            self._access_token_expires_at_utc: Optional[datetime] = None
+
+    @property
+    def access_token(self) -> Optional[str]:
+        return self._access_token if self.is_access_token_valid else None
+
+    @property
+    def is_access_token_valid(self) -> bool:
+        if not self._access_token:
+            return False
+
+        if self._access_token_expires_at_utc:
+            return datetime.now(tz=timezone.utc) < (
+                    self._access_token_expires_at_utc - self.token_refresh_before_expiry
+            )
+
+        return False
+
+    def set_cached_token(self, access_token: str, expires_at_utc: datetime) -> None:
+        self._access_token = access_token
+        self._access_token_expires_at_utc = expires_at_utc
+        self._set_cached_token()
+
+    def _set_cached_token(self) -> None:
+        raise NotImplementedError
+
+    def _get_cached_token(self) -> Optional[Tuple[str, datetime]]:
+        raise NotImplementedError

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -1,67 +1,13 @@
-import json
 import logging
-from datetime import datetime
-from pathlib import Path
-from typing import Generator, Optional, Tuple, Type, Callable, Union
+from typing import Generator, Optional
 
 import dateutil.parser
 import httpx
-from platformdirs import user_cache_dir
 
 from ..config import API_KEY, CONFIG, APIKey
 from . import USER_AGENT, RetryableHTTPClient, encode_json
-from .cache import CachedToken
-
+from .cache import ACCESS_TOKEN_CACHE_CLS_TYPE, FileCachedToken, get_access_token_cache_cache
 logger = logging.getLogger(__name__)
-
-
-class FileCachedToken(CachedToken):
-    def __init__(self):
-        self._cache_file = Path(user_cache_dir("syncsparkpy")) / "auth.json"
-
-        super().__init__()
-
-    def _get_cached_token(self) -> Optional[Tuple[str, datetime]]:
-        # Cache is optional, we can fail to read it and not worry
-        if self._cache_file.exists():
-            try:
-                cached_token = json.loads(self._cache_file.read_text())
-                cached_access_token = cached_token["access_token"]
-                cached_expiry = datetime.fromisoformat(cached_token["expires_at_utc"])
-                return cached_access_token, cached_expiry
-            except Exception as e:
-                logger.warning(
-                    f"Failed to read cached access token @ {self._cache_file}", exc_info=e
-                )
-
-        return None
-
-    def _set_cached_token(self) -> None:
-        # Cache is optional, we can fail to read it and not worry
-        try:
-            self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            self._cache_file.write_text(
-                json.dumps(
-                    {
-                        "access_token": self._access_token,
-                        "expires_at_utc": self._access_token_expires_at_utc.isoformat(),
-                    }
-                )
-            )
-        except Exception as e:
-            logger.warning(
-                f"Failed to write cached access token @ {self._cache_file}", exc_info=e
-            )
-
-
-# Putting this here instead of config.py because circular imports and typing.
-_access_token_cache_cls = FileCachedToken  # Default to local file caching.
-ACCESS_TOKEN_CACHE_CLS_TYPE = Union[Type[CachedToken], Callable[[], CachedToken]]
-
-
-def set_access_token_cache_cls(access_token_cache_cls: ACCESS_TOKEN_CACHE_CLS_TYPE) -> None:
-    global _access_token_cache_cls
-    _access_token_cache_cls = access_token_cache_cls
 
 
 class SyncAuth(httpx.Auth):
@@ -395,7 +341,7 @@ def get_default_client() -> SyncClient:
         _sync_client = SyncClient(
             CONFIG.api_url,
             API_KEY,
-            access_token_cache_cls=_access_token_cache_cls
+            access_token_cache_cls=get_access_token_cache_cache()
         )
     return _sync_client
 
@@ -409,6 +355,6 @@ def get_default_async_client() -> ASyncClient:
         _async_sync_client = ASyncClient(
             CONFIG.api_url,
             API_KEY,
-            access_token_cache_cls=_access_token_cache_cls
+            access_token_cache_cls=get_access_token_cache_cache()
         )
     return _async_sync_client

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Generator, Optional, Tuple, Type, Callable, Union
 
@@ -10,48 +10,9 @@ from platformdirs import user_cache_dir
 
 from ..config import API_KEY, CONFIG, APIKey
 from . import USER_AGENT, RetryableHTTPClient, encode_json
+from .cache import CachedToken
 
 logger = logging.getLogger(__name__)
-
-
-class CachedToken:
-    def __init__(self, token_refresh_before_expiry=timedelta(seconds=30)):
-        self.token_refresh_before_expiry = token_refresh_before_expiry
-
-        cache = self._get_cached_token()
-
-        if cache:
-            self._access_token, self._access_token_expires_at_utc = cache
-        else:
-            self._access_token: Optional[str] = None
-            self._access_token_expires_at_utc: Optional[datetime] = None
-
-    @property
-    def access_token(self) -> Optional[str]:
-        return self._access_token if self.is_access_token_valid else None
-
-    @property
-    def is_access_token_valid(self) -> bool:
-        if not self._access_token:
-            return False
-
-        if self._access_token_expires_at_utc:
-            return datetime.now(tz=timezone.utc) < (
-                    self._access_token_expires_at_utc - self.token_refresh_before_expiry
-            )
-
-        return False
-
-    def set_cached_token(self, access_token: str, expires_at_utc: datetime) -> None:
-        self._access_token = access_token
-        self._access_token_expires_at_utc = expires_at_utc
-        self._set_cached_token()
-
-    def _set_cached_token(self) -> None:
-        raise NotImplementedError
-
-    def _get_cached_token(self) -> Optional[Tuple[str, datetime]]:
-        raise NotImplementedError
 
 
 class FileCachedToken(CachedToken):
@@ -425,7 +386,7 @@ class ASyncClient(RetryableHTTPClient):
         return {"error": {"code": "Sync API Error", "message": "Transaction failure"}}
 
 
-_sync_client: SyncClient = None
+_sync_client: Optional[SyncClient] = None
 
 
 def get_default_client() -> SyncClient:
@@ -439,7 +400,7 @@ def get_default_client() -> SyncClient:
     return _sync_client
 
 
-_async_sync_client: ASyncClient = None
+_async_sync_client: Optional[ASyncClient] = None
 
 
 def get_default_async_client() -> ASyncClient:


### PR DESCRIPTION
# Summary

cache.py should be safe to import without breaking the rest.

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-2276)

Add any relevant testing examples or screenshots.