### PR TITLE
EBF: Enable azure retries 

### DIFF
--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1481,6 +1481,7 @@ def _poll_for_eventlog_from_dbfs(
                 f"No or incomplete event log data detected - attempting again in {poll_duration_seconds} seconds"
             )
             sleep(poll_duration_seconds)
+            eventlog_response = None
 
     if eventlog_response and eventlog_response.result:
         return eventlog_response

--- a/sync/_databricks.py
+++ b/sync/_databricks.py
@@ -1425,6 +1425,7 @@ def _poll_for_eventlog_from_s3(
                 f"No or incomplete event log data detected - attempting again in {poll_duration_seconds} seconds"
             )
             sleep(poll_duration_seconds)
+            eventlog_response = None
 
     if eventlog_response and eventlog_response.result:
         return eventlog_response


### PR DESCRIPTION
The while loop for azure eventlog retrieval is never entered because eventlog_response is populated after the first call. 