### PR TITLE
[PROD-2324] pin python-dateutil<3 to be less restrictive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "azure-mgmt-resource==23.0.1",
     "azure-cli-core==2.50.0",
     "platformdirs",
-    "python-dateutil<3",
+    "python-dateutil>=2.7,<3",
 ]
 dynamic = ["version", "description"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "azure-mgmt-resource==23.0.1",
     "azure-cli-core==2.50.0",
     "platformdirs",
-    "python-dateutil==2.9",
+    "python-dateutil<3",
 ]
 dynamic = ["version", "description"]
 

--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,5 +1,5 @@
 """Library for leveraging the power of Sync"""
 
-__version__ = "1.10.2"
+__version__ = "1.10.3"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
# Summary

customer got issue with strict pinning.

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-2324)

Add any relevant testing examples or screenshots.