### PR TITLE
[PROD-2408] Use new API for resolving project from job_id

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,5 +1,5 @@
 """Library for leveraging the power of Sync"""
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/api/projects.py
+++ b/sync/api/projects.py
@@ -118,6 +118,27 @@ def get_project_cluster_template(project_id: str, region_name: str = None) -> Re
     return Response(**get_default_client().get_project_cluster_template(project_id, params=params))
 
 
+def get_project_clusters(
+    workspace_id: str,
+    job_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> Response[List[dict]]:
+    """Retrieve a project clusters from a job_id or a run_id.
+
+    :param workspace_id: The Databricks workspace ID of the job or run.
+    :type workspace_id: str
+    :param job_id: The job ID to resolve the Sync project clusters for, will use last_run ID.
+    :type job_id: str, optional
+    :param run_id: The run ID to resolve the Sync project clusters for.
+    :type run_id: str, optional
+    :return: project object
+    :rtype: Response[dict]
+    """
+    return Response(
+        **get_default_client().get_project_clusters(workspace_id, job_id=job_id, run_id=run_id)
+    )
+
+
 def update_project(
     project_id: str,
     description: str = None,

--- a/sync/cli/_databricks.py
+++ b/sync/cli/_databricks.py
@@ -188,11 +188,13 @@ def get_cluster_report(
 @click.argument("job-id")
 @click.argument("project-id")
 @click.argument("recommendation-id")
+@click.argument("workspace-id")
 @pass_platform
 def apply_recommendation(
     platform: Platform,
     job_id: str,
     project_id: str,
+    workspace_id: str,
     recommendation_id: str = None,
 ):
     """Apply a project recommendation to a job"""
@@ -201,7 +203,9 @@ def apply_recommendation(
     elif platform is Platform.AZURE_DATABRICKS:
         import sync.azuredatabricks as databricks
 
-    response = databricks.apply_project_recommendation(job_id, project_id, recommendation_id)
+    response = databricks.apply_project_recommendation(
+        job_id, project_id, recommendation_id, workspace_id
+    )
     recommendation_id = response.result
     if recommendation_id:
         click.echo(f"Applied recommendation {recommendation_id} to job {job_id}")

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -112,6 +112,26 @@ class SyncClient(RetryableHTTPClient):
             self._client.build_request("GET", f"/v1/projects/{project_id}/cluster/template", params=params)
         )
 
+    def get_project_clusters(
+        self,
+        workspace_id: str,
+        job_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> dict:
+        """Get the project clusters from a job_id (will use last_run ID) or a run_id"""
+        params = {"workspace_id": workspace_id}
+        if job_id:
+            params["job_id"] = job_id
+        if run_id:
+            params["run_id"] = run_id
+
+        return self._send(
+            self._client.build_request(
+                "GET",
+                "/v1/projects/databricks/clusters",
+                params=params)
+        )
+
     def get_projects(self, params: dict = None) -> dict:
         return self._send(
             self._client.build_request("GET", "/v1/projects", params=params)


### PR DESCRIPTION
# Summary

Using the new route, I kept the old logic of getting the project_id from cluster tags as a backup.

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [x] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [x] File names are lower_snake_case
- [x] Relevant unit tests have been added or not applicable
- [x] Relevant documentation has been added or not applicable
- [x] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-2408)

Add any relevant testing examples or screenshots.