### PR TITLE
PROD-2618 add endpoint access for hardware override

### DIFF
--- a/sync/__init__.py
+++ b/sync/__init__.py
@@ -1,5 +1,5 @@
 """Library for leveraging the power of Sync"""
 
-__version__ = "1.11.4"
+__version__ = "1.11.5"
 
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/sync/clients/sync.py
+++ b/sync/clients/sync.py
@@ -138,6 +138,14 @@ class SyncClient(RetryableHTTPClient):
     def reset_project(self, project_id: str) -> dict:
         return self._send(self._client.build_request("POST", f"/v1/projects/{project_id}/reset"))
 
+    def project_hardware_override_aws(self, project_id: str, hardware_override: dict):
+        headers, content = encode_json(hardware_override)
+        return self._send(
+            self._client.build_request(
+                "POST", f"/v1/projects/{project_id}/hardware-override-aws", headers=headers, content=content
+            )
+        )
+
     def update_project(self, project_id: str, project: dict) -> dict:
         headers, content = encode_json(project)
         return self._send(


### PR DESCRIPTION
# Summary

Adds library access to the `hardware-override-aws` endpoint.

## Checklist

Before formally opening this PR, please adhere to the following standards:

- [ ] Branch/PR names begin with the related Jira ticket id (ie PROD-31) for Jira integration
- [ ] File names are lower_snake_case
- [ ] Relevant unit tests have been added or not applicable
- [ ] Relevant documentation has been added or not applicable
- [ ] Mark yourself as the assignee (makes it easier to scan the PR list)

[Related Jira Ticket](https://synccomputing.atlassian.net/browse/PROD-) (add id)

Add any relevant testing examples or screenshots.